### PR TITLE
SECC Connect Button Visibility Gate

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -340,7 +340,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var currentValue = ConnectionOpportunityId;
 
-                if ( currentValue != value )
+                if (currentValue != value)
                 {
                     ViewState["ConnectionOpportunityId"] = value;
                     SetBlockUserPreference( UserPreferenceKey.ConnectionOpportunityId, value.ToStringSafe() );
@@ -419,7 +419,7 @@ namespace RockWeb.Blocks.Connection
         {
             get
             {
-                if ( OnlyShowAssigned() )
+                if (OnlyShowAssigned())
                 {
                     return CurrentPersonAliasId;
                 }
@@ -442,7 +442,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var valueToReturn = ViewState["IsCardViewMode"].ToStringSafe().AsBooleanOrNull();
 
-                if ( !valueToReturn.HasValue )
+                if (!valueToReturn.HasValue)
                 {
                     var connectionType = GetConnectionType();
                     valueToReturn = connectionType == null ?
@@ -490,7 +490,7 @@ namespace RockWeb.Blocks.Connection
                 var value = ViewState["CurrentSortProperty"].ToStringSafe();
                 ConnectionRequestViewModelSortProperty sortProperty;
 
-                if ( !value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ) )
+                if (!value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ))
                 {
                     return sortProperty;
                 }
@@ -542,7 +542,7 @@ namespace RockWeb.Blocks.Connection
             // Configure the badge types
             var delimitedBadgeGuids = GetAttributeValue( AttributeKey.Badges );
 
-            if ( delimitedBadgeGuids.IsNullOrWhiteSpace() )
+            if (delimitedBadgeGuids.IsNullOrWhiteSpace())
             {
                 pnlRequestModalViewModeBadges.Visible = false;
                 return;
@@ -569,7 +569,7 @@ namespace RockWeb.Blocks.Connection
         {
             base.OnLoad( e );
 
-            if ( !Page.IsPostBack )
+            if (!Page.IsPostBack)
             {
                 LoadSettings();
                 BindUI();
@@ -579,13 +579,13 @@ namespace RockWeb.Blocks.Connection
                 var causingControlClientId = Request["__EVENTTARGET"].ToStringSafe();
                 var causingControl = Page.FindControl( causingControlClientId );
 
-                if ( causingControlClientId == lbJavaScriptCommand.ClientID )
+                if (causingControlClientId == lbJavaScriptCommand.ClientID)
                 {
                     // Handle card commands that are sent via JavaScript
                     ProcessJavaScriptCommand();
                 }
-                else if ( causingControl != null &&
-                    ( causingControl == ppRequesterFilter || causingControl.Parent == ppRequesterFilter ) )
+                else if (causingControl != null &&
+                    (causingControl == ppRequesterFilter || causingControl.Parent == ppRequesterFilter))
                 {
                     // If the postback comes from the filter drawer, don't modify the filter drawer CSS,
                     // which dictates if the drawer is open or closed
@@ -623,21 +623,21 @@ namespace RockWeb.Blocks.Connection
             int? newIndex;
             ParseDragEventArgument( argument, out action, out newStatusId, out requestId, out newIndex );
 
-            if ( action == "on-following-change" )
+            if (action == "on-following-change")
             {
                 BindFavoriteConnectionOpportunities();
                 BindConnectionTypesRepeater();
                 return;
             }
 
-            if ( !requestId.HasValue )
+            if (!requestId.HasValue)
             {
                 return;
             }
 
             ConnectionRequestId = requestId.Value;
 
-            if ( action == "view" )
+            if (action == "view")
             {
                 ViewAllActivities = false;
                 IsRequestModalAddEditMode = false;
@@ -646,16 +646,16 @@ namespace RockWeb.Blocks.Connection
                 return;
             }
 
-            if ( action == "connect" )
+            if (action == "connect")
             {
                 MarkRequestConnected();
                 RefreshRequestCard();
                 return;
             }
 
-            if ( action == "card-drop-confirmed" )
+            if (action == "card-drop-confirmed")
             {
-                if ( newStatusId.HasValue && newIndex.HasValue )
+                if (newStatusId.HasValue && newIndex.HasValue)
                 {
                     ProcessConfirmedDragEvent( newStatusId.Value, newIndex.Value );
                 }
@@ -675,7 +675,7 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestService( rockContext );
             var request = service.Get( ConnectionRequestId.Value );
 
-            if ( request == null )
+            if (request == null)
             {
                 return;
             }
@@ -685,9 +685,9 @@ namespace RockWeb.Blocks.Connection
             rockContext.SaveChanges();
 
             // Reordering is only allowed when the cards are sorted by order
-            if ( CurrentSortProperty == ConnectionRequestViewModelSortProperty.Order )
+            if (CurrentSortProperty == ConnectionRequestViewModelSortProperty.Order)
             {
-                if ( request.ConnectionStatusId == newStatusId )
+                if (request.ConnectionStatusId == newStatusId)
                 {
                     var requestsOfStatus = service.Queryable()
                     .Where( r =>
@@ -706,9 +706,9 @@ namespace RockWeb.Blocks.Connection
                     var orderValues = requestsOfStatus.Select( r => r.Order ).ToList();
                     var previousValue = -1;
 
-                    for ( var i = 0; i < orderValues.Count; i++ )
+                    for (var i = 0; i < orderValues.Count; i++)
                     {
-                        if ( orderValues[i] <= previousValue )
+                        if (orderValues[i] <= previousValue)
                         {
                             orderValues[i] = previousValue + 1;
                         }
@@ -719,12 +719,12 @@ namespace RockWeb.Blocks.Connection
                     requestsOfStatus.Remove( request );
                     requestsOfStatus.Insert( newIndex, request );
 
-                    for ( var i = 0; i < orderValues.Count; i++ )
+                    for (var i = 0; i < orderValues.Count; i++)
                     {
                         requestsOfStatus[i].Order = orderValues[i];
                     }
 
-                    if ( orderValues.Count < requestsOfStatus.Count )
+                    if (orderValues.Count < requestsOfStatus.Count)
                     {
                         // This happens if the card came from another column. The remove did nothing, but
                         // we added the new request. Therefore we need to set the last request to the
@@ -770,7 +770,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private string GetEmailLinkMarkup( int? personId, string emailAddress )
         {
-            if ( !personId.HasValue || emailAddress.IsNullOrWhiteSpace() )
+            if (!personId.HasValue || emailAddress.IsNullOrWhiteSpace())
             {
                 return string.Empty;
             }
@@ -784,13 +784,13 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private string GetStatusIconHtml( ConnectionRequestViewModel viewModel )
         {
-            if ( viewModel == null )
+            if (viewModel == null)
             {
                 return string.Empty;
             }
 
             var connectionType = GetConnectionType();
-            var daysUntilRequestIdle = connectionType == null ? ( int? ) null : connectionType.DaysUntilRequestIdle;
+            var daysUntilRequestIdle = connectionType == null ? (int?) null : connectionType.DaysUntilRequestIdle;
             var connectionRequestStatusIconTemplate = GetAttributeValue( AttributeKey.ConnectionRequestStatusIconsTemplate );
             var mergeFields = new Dictionary<string, object>();
 
@@ -802,7 +802,7 @@ namespace RockWeb.Blocks.Connection
                 viewModel.IsUnassigned
             };
 
-            if ( LavaService.RockLiquidIsEnabled )
+            if (LavaService.RockLiquidIsEnabled)
             {
                 mergeFields.Add( "ConnectionRequestStatusIcons", DotLiquid.Hash.FromAnonymousObject( connectionRequestStatusIcons ) );
             }
@@ -825,7 +825,7 @@ namespace RockWeb.Blocks.Connection
             var connectionRequest = GetConnectionRequest();
             var requesterPerson = GetRequesterPerson();
 
-            if ( viewModel == null || connectionRequest == null || requesterPerson == null )
+            if (viewModel == null || connectionRequest == null || requesterPerson == null)
             {
                 return;
             }
@@ -854,7 +854,6 @@ namespace RockWeb.Blocks.Connection
             lRequestModalViewModeEmail.Text = GetEmailLinkMarkup( viewModel.PersonId, viewModel.PersonEmail );
             aRequestModalViewModeProfileLink.Attributes["href"] = string.Format( "/person/{0}", viewModel.PersonId );
             btnRequestModalViewModeTransfer.Visible = DoShowTransferButton();
-
             /* 
                 08/09/2022 - SK
                 This is special case where we are not using viewModel.CanConnect in order to make this align with older ConnectionRequestDetail block.
@@ -866,7 +865,9 @@ namespace RockWeb.Blocks.Connection
                 viewModel.ConnectionState != ConnectionState.Inactive &&
                 viewModel.ConnectionState != ConnectionState.Connected &&
                 connectionRequest.ConnectionOpportunity.ShowConnectButton &&
-                CanUserEditConnectionRequest();
+                CanUserEditConnectionRequest() &&
+                CanUserConnect();
+
             btnRequestModalViewModeEdit.Visible = CanUserEditConnectionRequest();
             lbRequestModalViewModeAddActivity.Visible = CanUserEditConnectionRequest();
             rRequestModalViewModeConnectorSelect.Visible = CanUserEditConnectionRequest();
@@ -878,7 +879,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var smsLinkHtml = string.Empty;
 
-                if ( hasSmsLink && p.IsMessagingEnabled )
+                if (hasSmsLink && p.IsMessagingEnabled)
                 {
                     var smsLink = LinkedPageUrl(
                         AttributeKey.SmsLinkPage,
@@ -900,7 +901,7 @@ namespace RockWeb.Blocks.Connection
             // Build the description list on the right side
             var rightDescList = new DescriptionList();
 
-            if ( viewModel.DateOpened.HasValue )
+            if (viewModel.DateOpened.HasValue)
             {
                 rightDescList.Add(
                     "Request Date",
@@ -910,7 +911,7 @@ namespace RockWeb.Blocks.Connection
             // Placement group HTML
             var placementGroupHtml = string.Empty;
 
-            if ( viewModel.GroupName.IsNullOrWhiteSpace() )
+            if (viewModel.GroupName.IsNullOrWhiteSpace())
             {
                 placementGroupHtml = "None Assigned";
             }
@@ -925,7 +926,7 @@ namespace RockWeb.Blocks.Connection
 
                 placementGroupHtml = string.Format( "<a href=\"{0}\">{1}</a>", groupDetailPageUrl, viewModel.GroupName );
 
-                if ( viewModel.PlacementGroupRoleId.HasValue )
+                if (viewModel.PlacementGroupRoleId.HasValue)
                 {
                     var rockContext = new RockContext();
                     var service = new GroupTypeRoleService( rockContext );
@@ -934,7 +935,7 @@ namespace RockWeb.Blocks.Connection
                     var roleName = role != null ? role.Name : string.Empty;
                     var statusName = viewModel.PlacementGroupMemberStatus.ConvertToStringSafe();
 
-                    if ( !string.IsNullOrWhiteSpace( roleName ) || !string.IsNullOrWhiteSpace( statusName ) )
+                    if (!string.IsNullOrWhiteSpace( roleName ) || !string.IsNullOrWhiteSpace( statusName ))
                     {
                         placementGroupHtml += string.Format(
                             " ({0}{1}{2})",
@@ -943,7 +944,7 @@ namespace RockWeb.Blocks.Connection
                             roleName );
                     }
 
-                    if ( viewModel.PlacementGroupId.HasValue )
+                    if (viewModel.PlacementGroupId.HasValue)
                     {
                         var groupMember = new GroupMember();
                         groupMember.Group = connectionRequest.AssignedGroup;
@@ -954,12 +955,12 @@ namespace RockWeb.Blocks.Connection
 
                         groupMember.LoadAttributes();
 
-                        if ( connectionRequest.AssignedGroupMemberAttributeValues.IsNotNullOrWhiteSpace() )
+                        if (connectionRequest.AssignedGroupMemberAttributeValues.IsNotNullOrWhiteSpace())
                         {
                             var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( connectionRequest.AssignedGroupMemberAttributeValues );
-                            if ( savedValues != null )
+                            if (savedValues != null)
                             {
-                                foreach ( var item in savedValues )
+                                foreach (var item in savedValues)
                                 {
                                     groupMember.SetAttributeValue( item.Key, item.Value );
                                 }
@@ -994,7 +995,7 @@ namespace RockWeb.Blocks.Connection
             BindModalViewModeConnectorOptions();
 
             // Render the current view mode for the modal (activities grid or add activity form)
-            if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_AddEditActivity )
+            if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_AddEditActivity)
             {
                 var activity = GetCurrentActivity();
                 var connectorPersonAliasId = activity == null ? null : activity.ConnectorPersonAliasId;
@@ -1014,10 +1015,10 @@ namespace RockWeb.Blocks.Connection
                 BindConnectorOptions( ddlRequestModalViewModeAddActivityModeConnector, true, viewModel.CampusId, connectorPersonAliasId );
 
                 // Bind edit mode if appropriate
-                if ( activity != null )
+                if (activity != null)
                 {
                     tbRequestModalViewModeAddActivityModeNote.Text = activity.Note;
-                    ddlRequestModalViewModeAddActivityModeConnector.SelectedValue = ( connectorPersonAliasId ?? 0 ).ToStringSafe();
+                    ddlRequestModalViewModeAddActivityModeConnector.SelectedValue = (connectorPersonAliasId ?? 0).ToStringSafe();
                     ddlRequestModalViewModeAddActivityModeType.SelectedValue = activity.ConnectionActivityTypeId.ToString();
                 }
                 else
@@ -1026,7 +1027,7 @@ namespace RockWeb.Blocks.Connection
                     tbRequestModalViewModeAddActivityModeNote.Text = string.Empty;
                 }
             }
-            else if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_View )
+            else if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_View)
             {
                 divRequestModalViewModeAddActivityMode.Visible = false;
                 divRequestModalViewModeActivityGridMode.Visible = true;
@@ -1035,8 +1036,8 @@ namespace RockWeb.Blocks.Connection
                 BindRequestModalViewModeActivitiesGrid();
                 BindRequestModalViewModeWorkflowsGrid();
             }
-            else if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_Transfer ||
-                RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch )
+            else if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_Transfer ||
+                RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch)
             {
                 divRequestModalViewModeAddActivityMode.Visible = false;
                 divRequestModalViewModeActivityGridMode.Visible = false;
@@ -1046,7 +1047,7 @@ namespace RockWeb.Blocks.Connection
                 ddlRequestModalViewModeTransferModeStatus.Items.Clear();
                 var statuses = GetConnectionType().ConnectionStatuses;
 
-                foreach ( var status in statuses )
+                foreach (var status in statuses)
                 {
                     ddlRequestModalViewModeTransferModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString() ) );
                 }
@@ -1060,7 +1061,7 @@ namespace RockWeb.Blocks.Connection
                 ddlRequestModalViewModeTransferModeOpportunity.Items.Clear();
                 var opportunities = GetConnectionOpportunities();
 
-                foreach ( var opportunity in opportunities.OrderBy( o => o.Order ).ThenBy( o => o.Name ) )
+                foreach (var opportunity in opportunities.OrderBy( o => o.Order ).ThenBy( o => o.Name ))
                 {
                     ddlRequestModalViewModeTransferModeOpportunity.Items.Add( new ListItem( opportunity.Name, opportunity.Id.ToString().ToUpper() ) );
                     hasOriginalOpportunity |= opportunity.Id == originalTargetOpportunityId;
@@ -1076,7 +1077,7 @@ namespace RockWeb.Blocks.Connection
                     "Current Connector: {0}",
                     viewModel.ConnectorPersonFullname.IsNullOrWhiteSpace() ? "No Connector" : viewModel.ConnectorPersonFullname );
 
-                if ( hasOriginalOpportunity )
+                if (hasOriginalOpportunity)
                 {
                     ddlRequestModalViewModeTransferModeOpportunity.SetValue( originalTargetOpportunityId ?? viewModel.ConnectionOpportunityId );
                 }
@@ -1087,7 +1088,7 @@ namespace RockWeb.Blocks.Connection
 
                 ddlRequestModalViewModeTransferModeOpportunity_SelectedIndexChanged( null, null );
 
-                if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch )
+                if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch)
                 {
                     ShowSearchModal();
                 }
@@ -1101,7 +1102,7 @@ namespace RockWeb.Blocks.Connection
             mdRequest.SubTitle = GetRequestDetailModalHeaderLabelMarkup();
 
             // Show group requirement issues if any
-            if ( viewModel.PlacementGroupId.HasValue )
+            if (viewModel.PlacementGroupId.HasValue)
             {
                 pnlRequestModalViewModeRequirements.Visible = true;
                 ShowRequestModalViewModeRequirementsStatuses();
@@ -1122,7 +1123,7 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if ( viewModel == null )
+            if (viewModel == null)
             {
                 return string.Empty;
             }
@@ -1130,7 +1131,7 @@ namespace RockWeb.Blocks.Connection
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine( @"<div class=""panel-labels"" style=""text-align: right;"">" );
 
-            if ( !viewModel.CampusName.IsNullOrWhiteSpace() )
+            if (!viewModel.CampusName.IsNullOrWhiteSpace())
             {
                 stringBuilder.AppendLine( GetLabelMarkup( "campus", viewModel.CampusName ) );
             }
@@ -1192,13 +1193,13 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void ShowRequestModal()
         {
-            if ( IsRequestModalAddMode() )
+            if (IsRequestModalAddMode())
             {
                 divRequestModalAddEditMode.Visible = true;
                 divRequestModalViewMode.Visible = false;
                 BindRequestModalAddEditMode();
             }
-            else if ( IsRequestModalEditMode() )
+            else if (IsRequestModalEditMode())
             {
                 divRequestModalAddEditMode.Visible = true;
                 divRequestModalViewMode.Visible = false;
@@ -1227,7 +1228,7 @@ namespace RockWeb.Blocks.Connection
         {
             HideRequestModalNotification();
 
-            if ( IsRequestModalAddMode() )
+            if (IsRequestModalAddMode())
             {
                 mdRequest.Hide();
             }
@@ -1245,7 +1246,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbRequestModalAddEditModeSave_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -1269,7 +1270,7 @@ namespace RockWeb.Blocks.Connection
 
             // If a value is selected in the radio button list, use it, otherwise use "Active".
             // This prevents the "FutureFollowUp" State from remaining on a Connection Request if the Connection Type's "Enable Future Follow-up" was unchecked.
-            if ( state.HasValue )
+            if (state.HasValue)
             {
                 connectionRequest.ConnectionState = rblRequestModalAddEditModeState.SelectedValueAsEnum<ConnectionState>();
             }
@@ -1286,7 +1287,7 @@ namespace RockWeb.Blocks.Connection
             connectionRequest.Comments = tbRequestModalAddEditModeComments.Text.SanitizeHtml();
 
             // If this request is a Future FollowUp state, use the selected date from the date picker, otherwise it should be null.
-            if ( connectionRequest.ConnectionState == ConnectionState.FutureFollowUp )
+            if (connectionRequest.ConnectionState == ConnectionState.FutureFollowUp)
             {
                 connectionRequest.FollowupDate = dpRequestModalAddEditModeFollowUp.SelectedDate;
             }
@@ -1302,7 +1303,7 @@ namespace RockWeb.Blocks.Connection
             // So, make sure a message is displayed in the validation summary.
             cvRequestModalCustomValidator.IsValid = connectionRequest.IsValid;
 
-            if ( !cvRequestModalCustomValidator.IsValid )
+            if (!cvRequestModalCustomValidator.IsValid)
             {
                 cvRequestModalCustomValidator.ErrorMessage = connectionRequest.ValidationResults
                     .Select( a => a.ErrorMessage )
@@ -1311,7 +1312,7 @@ namespace RockWeb.Blocks.Connection
                 return;
             }
 
-            if ( isAddMode )
+            if (isAddMode)
             {
                 connectionRequestService.Add( connectionRequest );
             }
@@ -1325,14 +1326,14 @@ namespace RockWeb.Blocks.Connection
             _connectionRequest = connectionRequest;
 
             // Add an activity that the connector was assigned (or changed)
-            if ( originalConnectorPersonAliasId != newConnectorPersonAliasId )
+            if (originalConnectorPersonAliasId != newConnectorPersonAliasId)
             {
                 AddAssignedActivity();
             }
 
             BindUI();
 
-            if ( isAddMode )
+            if (isAddMode)
             {
                 // Return to the board or grid
                 ConnectionRequestId = connectionRequest.Id;
@@ -1345,7 +1346,7 @@ namespace RockWeb.Blocks.Connection
                 ShowRequestModal();
             }
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -1362,14 +1363,14 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if ( viewModel == null || !viewModel.ConnectorPersonAliasId.HasValue )
+            if (viewModel == null || !viewModel.ConnectorPersonAliasId.HasValue)
             {
                 return;
             }
 
             var rockContext = new RockContext();
 
-            if ( _assignedActivityId == 0 )
+            if (_assignedActivityId == 0)
             {
                 var guid = Rock.SystemGuid.ConnectionActivityType.ASSIGNED.AsGuid();
                 _assignedActivityId = new ConnectionActivityTypeService( rockContext ).Queryable()
@@ -1379,7 +1380,7 @@ namespace RockWeb.Blocks.Connection
                     .FirstOrDefault();
             }
 
-            if ( _assignedActivityId > 0 )
+            if (_assignedActivityId > 0)
             {
                 var connectionRequestActivityService = new ConnectionRequestActivityService( rockContext );
                 var connectionRequestActivity = new ConnectionRequestActivity
@@ -1404,13 +1405,13 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected void ppRequestModalAddEditModePerson_SelectPerson( object sender, EventArgs e )
         {
-            if ( !ppRequestModalAddEditModePerson.PersonId.HasValue )
+            if (!ppRequestModalAddEditModePerson.PersonId.HasValue)
             {
                 CheckRequestModalAddEditModeGroupRequirements();
                 return;
             }
 
-            using ( var rockContext = new RockContext() )
+            using (var rockContext = new RockContext())
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionOpportunity = GetConnectionOpportunity();
@@ -1421,10 +1422,10 @@ namespace RockWeb.Blocks.Connection
                     .Where( r =>
                         r.PersonAliasId == ppRequestModalAddEditModePerson.PersonAliasId.Value &&
                         r.ConnectionOpportunityId == connectionOpportunity.Id &&
-                        ( r.ConnectionState == ConnectionState.Active || r.ConnectionState == ConnectionState.FutureFollowUp ) )
+                        (r.ConnectionState == ConnectionState.Active || r.ConnectionState == ConnectionState.FutureFollowUp) )
                     .Any();
 
-                if ( hasRequest )
+                if (hasRequest)
                 {
                     var text = string.Format(
                         "There is already an active (or future follow up) request in the '{0}' opportunity for {1}.",
@@ -1451,16 +1452,16 @@ namespace RockWeb.Blocks.Connection
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt();
             var roleId = ddlRequestModalAddEditModePlacementRole.SelectedValueAsInt();
 
-            if ( !personId.HasValue || !groupId.HasValue || !roleId.HasValue )
+            if (!personId.HasValue || !groupId.HasValue || !roleId.HasValue)
             {
                 return;
             }
 
-            using ( var rockContext = new RockContext() )
+            using (var rockContext = new RockContext())
             {
                 var group = new GroupService( rockContext ).Get( groupId.Value );
 
-                if ( group == null )
+                if (group == null)
                 {
                     return;
                 }
@@ -1470,7 +1471,7 @@ namespace RockWeb.Blocks.Connection
                     personId.Value,
                     roleId.Value );
 
-                if ( requirementsResults != null && requirementsResults
+                if (requirementsResults != null && requirementsResults
                     .Any( r =>
                     r.GroupRequirement.MustMeetRequirementToAddMember &&
                     r.MeetsGroupRequirement == MeetsGroupRequirement.NotMet &&
@@ -1478,7 +1479,7 @@ namespace RockWeb.Blocks.Connection
                     )
                 {
                     var person = new PersonService( rockContext ).Get( personId.Value );
-                    if ( person != null )
+                    if (person != null)
                     {
                         var text = string.Format(
                             "{0} does not currently meet the requirements for the selected group/role and will not be able to be placed.",
@@ -1520,12 +1521,12 @@ namespace RockWeb.Blocks.Connection
             BindConnectorOptions( ddlRequestModalAddEditModeConnector, true, campusId, connectorPersonAliasId );
             ddlRequestModalAddEditModeConnector.SetValue( connectorPersonAliasId );
 
-            if ( connectorPersonAliasId == 0 )
+            if (connectorPersonAliasId == 0)
             {
                 // Select the default connector for the campus
                 var connectionOpportunity = GetConnectionOpportunity();
 
-                if ( connectionOpportunity != null )
+                if (connectionOpportunity != null)
                 {
                     var defaultConnectorPersonAliasId = connectionOpportunity.GetDefaultConnectorPersonAliasId( campusId );
                     ddlRequestModalAddEditModeConnector.SetValue( defaultConnectorPersonAliasId );
@@ -1551,7 +1552,7 @@ namespace RockWeb.Blocks.Connection
             var groups = GetAvailablePlacementGroups( campusId );
 
             // Add the currently assigned group if it hasn't been added already
-            if ( viewModel != null && viewModel.PlacementGroupId.HasValue && !groups.Any( g => g.Id == viewModel.PlacementGroupId ) )
+            if (viewModel != null && viewModel.PlacementGroupId.HasValue && !groups.Any( g => g.Id == viewModel.PlacementGroupId ))
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1567,13 +1568,13 @@ namespace RockWeb.Blocks.Connection
                     } )
                     .FirstOrDefault();
 
-                if ( currentGroup != null )
+                if (currentGroup != null)
                 {
                     groups.Add( currentGroup );
                 }
             }
 
-            foreach ( var g in groups.OrderBy( g => g.Name ).ThenBy( g => g.Id ) )
+            foreach (var g in groups.OrderBy( g => g.Name ).ThenBy( g => g.Id ))
             {
                 var text = string.Format(
                     "{0} ({1})",
@@ -1605,7 +1606,7 @@ namespace RockWeb.Blocks.Connection
             var isFutureFollowUp = !rblRequestModalAddEditModeState.SelectedValue.IsNullOrWhiteSpace() &&
                 rblRequestModalAddEditModeState.SelectedValueAsEnum<ConnectionState>() == ConnectionState.FutureFollowUp;
 
-            if ( isFutureFollowUp )
+            if (isFutureFollowUp)
             {
                 dpRequestModalAddEditModeFollowUp.Visible = true;
                 dpRequestModalAddEditModeFollowUp.Required = true;
@@ -1644,7 +1645,7 @@ namespace RockWeb.Blocks.Connection
             var requestGroupId = request != null ? request.PlacementGroupId : null;
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt() ?? requestGroupId;
 
-            if ( groupId.HasValue )
+            if (groupId.HasValue)
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1669,7 +1670,7 @@ namespace RockWeb.Blocks.Connection
                     .ToList()
                     .Distinct();
 
-                foreach ( var role in roles )
+                foreach (var role in roles)
                 {
                     var listItem = new ListItem( role.RoleName, role.RoleId.ToString() );
                     listItem.Selected = currentRoleId.HasValue && currentRoleId.Value == role.RoleId;
@@ -1696,7 +1697,7 @@ namespace RockWeb.Blocks.Connection
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt();
             var roleId = ddlRequestModalAddEditModePlacementRole.SelectedValueAsInt();
 
-            if ( groupId.HasValue && roleId.HasValue )
+            if (groupId.HasValue && roleId.HasValue)
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1717,9 +1718,9 @@ namespace RockWeb.Blocks.Connection
                     .ToList()
                     .Distinct();
 
-                foreach ( var status in statuses )
+                foreach (var status in statuses)
                 {
-                    var intValue = ( int ) status;
+                    var intValue = (int) status;
                     var listItem = new ListItem( status.ToString(), intValue.ToString() );
                     listItem.Selected = currentStatus.HasValue && currentStatus.Value.ConvertToInt() == intValue;
                     ddlRequestModalAddEditModePlacementStatus.Items.Add( listItem );
@@ -1741,7 +1742,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="setValues">if set to <c>true</c> [set values].</param>
         private void BuildRequestModalAddEditModeGroupMemberAttributes( int? groupId, int? groupMemberRoleId, GroupMemberStatus? groupMemberStatus, bool setValues )
         {
-            if ( !groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue )
+            if (!groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue)
             {
                 avcRequestModalAddEditModeGroupMember.AddEditControls( null, true );
                 return;
@@ -1757,12 +1758,12 @@ namespace RockWeb.Blocks.Connection
             groupMember.LoadAttributes();
             var request = GetConnectionRequest();
 
-            if ( request != null && !request.AssignedGroupMemberAttributeValues.IsNullOrWhiteSpace() )
+            if (request != null && !request.AssignedGroupMemberAttributeValues.IsNullOrWhiteSpace())
             {
                 var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( request.AssignedGroupMemberAttributeValues );
-                if ( savedValues != null )
+                if (savedValues != null)
                 {
-                    foreach ( var item in savedValues )
+                    foreach (var item in savedValues)
                     {
                         groupMember.SetAttributeValue( item.Key, item.Value );
                     }
@@ -1787,7 +1788,7 @@ namespace RockWeb.Blocks.Connection
 
             var values = new Dictionary<string, string>();
 
-            if ( !groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue )
+            if (!groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue)
             {
                 return string.Empty;
             }
@@ -1802,7 +1803,7 @@ namespace RockWeb.Blocks.Connection
             groupMember.LoadAttributes();
             avcRequestModalAddEditModeGroupMember.GetEditValues( groupMember );
 
-            foreach ( var attrValue in groupMember.AttributeValues )
+            foreach (var attrValue in groupMember.AttributeValues)
             {
                 values.Add( attrValue.Key, attrValue.Value.Value );
             }
@@ -1817,7 +1818,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbAddRequest_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -1840,18 +1841,20 @@ namespace RockWeb.Blocks.Connection
             var connectionType = GetConnectionType();
 
             BindConnectorOptions( ddlRequestModalAddEditModeConnector, true, campusId, connectorPersonAliasId );
-
-            ConnectionState[] ignoredConnectionTypes = { };
+            List<ConnectionState> ignoredConnectionTypes = new List<ConnectionState>();
 
             // If this Connection Type does not allow Future Follow-Up, ignore it from the ConnectionState types.
-            if ( !connectionType.EnableFutureFollowup )
+            if (!connectionType.EnableFutureFollowup)
             {
-                ignoredConnectionTypes = new ConnectionState[] { ConnectionState.FutureFollowUp };
+                ignoredConnectionTypes.Add( ConnectionState.FutureFollowUp );
             }
 
+            if (!CanUserConnect())
+            {
+                ignoredConnectionTypes.Add( ConnectionState.Connected );
+            }
             // Ignore binding the Connection Types that are in the provided array.
-            rblRequestModalAddEditModeState.BindToEnum( ignoreTypes: ignoredConnectionTypes );
-
+            rblRequestModalAddEditModeState.BindToEnum( ignoreTypes: ignoredConnectionTypes.ToArray() );
             // Status
             rblRequestModalAddEditModeStatus.Items.Clear();
             var allStatuses = connectionType.ConnectionStatuses
@@ -1859,16 +1862,16 @@ namespace RockWeb.Blocks.Connection
                 .ThenByDescending( cs => cs.IsDefault )
                 .ThenBy( cs => cs.Name );
 
-            foreach ( var status in allStatuses )
+            foreach (var status in allStatuses)
             {
                 // Add Status to selection list only if marked as active or currently selected.
-                if ( status.IsActive )
+                if (status.IsActive)
                 {
                     rblRequestModalAddEditModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString().ToUpper() ) );
                 }
             }
 
-            if ( viewModel != null )
+            if (viewModel != null)
             {
                 var rockContext = new RockContext();
                 var personService = new PersonService( rockContext );
@@ -1877,12 +1880,12 @@ namespace RockWeb.Blocks.Connection
                 ppRequestModalAddEditModePerson.SetValue( requestor );
                 ddlRequestModalAddEditModeConnector.SetValue( connectorPersonAliasId );
 
-                rblRequestModalAddEditModeState.SetValue( ( int ) viewModel.ConnectionState );
+                rblRequestModalAddEditModeState.SetValue( (int) viewModel.ConnectionState );
                 tbRequestModalAddEditModeComments.Text = viewModel.Comments;
                 rblRequestModalAddEditModeStatus.SetValue( viewModel.StatusId );
                 ddlRequestModalAddEditModePlacementGroup.SetValue( viewModel.PlacementGroupId );
                 ddlRequestModalAddEditModePlacementRole.SetValue( viewModel.PlacementGroupRoleId );
-                ddlRequestModalAddEditModePlacementStatus.SetValue( ( int? ) viewModel.PlacementGroupMemberStatus );
+                ddlRequestModalAddEditModePlacementStatus.SetValue( (int?) viewModel.PlacementGroupMemberStatus );
                 dpRequestModalAddEditModeFollowUp.SelectedDate = viewModel.FollowupDate;
             }
             else
@@ -1893,7 +1896,7 @@ namespace RockWeb.Blocks.Connection
                 // Clear controls and set defaults
                 var defaultStatus = allStatuses.FirstOrDefault( s => s.IsDefault );
 
-                if ( defaultStatus != null )
+                if (defaultStatus != null)
                 {
                     rblRequestModalAddEditModeStatus.SetValue( defaultStatus.Id );
                 }
@@ -1909,7 +1912,7 @@ namespace RockWeb.Blocks.Connection
 
                 var connectionOpportunity = GetConnectionOpportunity();
 
-                if ( connectionOpportunity != null )
+                if (connectionOpportunity != null)
                 {
                     var defaultConnectorPersonAliasId = connectionOpportunity.GetDefaultConnectorPersonAliasId( campusId );
                     ddlRequestModalAddEditModeConnector.SetValue( defaultConnectorPersonAliasId );
@@ -1944,7 +1947,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if ( connectionOpportunity == null )
+            if (connectionOpportunity == null)
             {
                 return;
             }
@@ -1958,15 +1961,15 @@ namespace RockWeb.Blocks.Connection
                 .Distinct();
 
             var authorizedWorkflows = new List<ConnectionWorkflow>();
-            foreach ( var manualWorkflow in manualWorkflows )
+            foreach (var manualWorkflow in manualWorkflows)
             {
-                if ( ( manualWorkflow.WorkflowType.IsActive ?? true ) && manualWorkflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ) )
+                if ((manualWorkflow.WorkflowType.IsActive ?? true) && manualWorkflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ))
                 {
                     authorizedWorkflows.Add( manualWorkflow );
                 }
             }
 
-            if ( authorizedWorkflows.Any() )
+            if (authorizedWorkflows.Any())
             {
                 divRequestModalViewModeWorkflows.Visible = true;
                 rptRequestWorkflows.DataSource = authorizedWorkflows.ToList();
@@ -1987,7 +1990,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionWorkflowId = e.CommandArgument.ToStringSafe().AsInteger();
 
-            if ( e.CommandName != "LaunchWorkflow" || connectionWorkflowId == 0 || !ConnectionRequestId.HasValue )
+            if (e.CommandName != "LaunchWorkflow" || connectionWorkflowId == 0 || !ConnectionRequestId.HasValue)
             {
                 return;
             }
@@ -1998,21 +2001,21 @@ namespace RockWeb.Blocks.Connection
             var connectionWorkflowService = new ConnectionWorkflowService( rockContext );
             var connectionWorkflow = connectionWorkflowService.Get( connectionWorkflowId );
 
-            if ( connectionWorkflow == null || connectionRequest == null )
+            if (connectionWorkflow == null || connectionRequest == null)
             {
                 return;
             }
 
             var workflowType = connectionWorkflow.WorkflowTypeCache;
 
-            if ( workflowType == null || workflowType.IsActive == false )
+            if (workflowType == null || workflowType.IsActive == false)
             {
                 return;
             }
 
             var workflow = Workflow.Activate( workflowType, connectionWorkflow.WorkflowType.WorkTerm, rockContext );
 
-            if ( workflow == null )
+            if (workflow == null)
             {
                 return;
             }
@@ -2020,9 +2023,9 @@ namespace RockWeb.Blocks.Connection
             var workflowService = new WorkflowService( rockContext );
             List<string> workflowErrors;
 
-            if ( workflowService.Process( workflow, connectionRequest, out workflowErrors ) )
+            if (workflowService.Process( workflow, connectionRequest, out workflowErrors ))
             {
-                if ( workflow.Id != 0 )
+                if (workflow.Id != 0)
                 {
                     new ConnectionRequestWorkflowService( rockContext ).Add( new ConnectionRequestWorkflow
                     {
@@ -2035,7 +2038,7 @@ namespace RockWeb.Blocks.Connection
 
                     rockContext.SaveChanges();
 
-                    if ( workflow.HasActiveEntryForm( CurrentPerson ) )
+                    if (workflow.HasActiveEntryForm( CurrentPerson ))
                     {
                         var message = $"A '{workflowType.Name}' workflow has been started.<br><br>The new workflow has an active form that is ready for input.";
 
@@ -2176,14 +2179,14 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
         protected void gRequests_RowDataBound( object sender, GridViewRowEventArgs e )
         {
-            if ( e.Row.RowType != DataControlRowType.DataRow )
+            if (e.Row.RowType != DataControlRowType.DataRow)
             {
                 return;
             }
 
             var viewModel = e.Row.DataItem as ConnectionRequestViewModel;
 
-            if ( viewModel == null )
+            if (viewModel == null)
             {
                 return;
             }
@@ -2191,7 +2194,7 @@ namespace RockWeb.Blocks.Connection
             // Status icons
             var lStatusIcons = e.Row.FindControl( "lStatusIcons" ) as Literal;
 
-            if ( lStatusIcons != null )
+            if (lStatusIcons != null)
             {
                 lStatusIcons.Text = GetStatusIconHtml( viewModel );
             }
@@ -2199,7 +2202,7 @@ namespace RockWeb.Blocks.Connection
             // Status
             var lStatus = e.Row.FindControl( "lStatus" ) as Literal;
 
-            if ( lStatus != null )
+            if (lStatus != null)
             {
                 lStatus.Text = string.Format(
                     @"<span class=""label label-default"" style=""background-color: {0}"">{1}</span>",
@@ -2210,7 +2213,7 @@ namespace RockWeb.Blocks.Connection
             // State
             var lState = e.Row.FindControl( "lState" ) as Literal;
 
-            if ( lState != null )
+            if (lState != null)
             {
                 lState.Text = viewModel.StateLabel;
             }
@@ -2245,9 +2248,9 @@ namespace RockWeb.Blocks.Connection
 
             var authorizedWorkflows = new List<ConnectionRequestWorkflow>();
 
-            foreach ( var requestWorkfFlow in instantiatedWorkflows )
+            foreach (var requestWorkfFlow in instantiatedWorkflows)
             {
-                if ( requestWorkfFlow.Workflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ) )
+                if (requestWorkfFlow.Workflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ))
                 {
                     authorizedWorkflows.Add( requestWorkfFlow );
                 }
@@ -2270,7 +2273,7 @@ namespace RockWeb.Blocks.Connection
 
             gRequestModalViewModeWorkflows.DataBind();
 
-            if ( !authorizedWorkflows.Any() )
+            if (!authorizedWorkflows.Any())
             {
                 wpRequestModalViewModeWorkflow.Visible = false;
             }
@@ -2299,12 +2302,12 @@ namespace RockWeb.Blocks.Connection
                 .Where( w => w.Guid == guid )
                 .FirstOrDefault();
 
-            if ( requestWorkflow == null || requestWorkflow.Workflow == null )
+            if (requestWorkflow == null || requestWorkflow.Workflow == null)
             {
                 return;
             }
 
-            if ( requestWorkflow.Workflow.HasActiveEntryForm( CurrentPerson ) )
+            if (requestWorkflow.Workflow.HasActiveEntryForm( CurrentPerson ))
             {
                 RegisterWorkflowDetailPageScript( requestWorkflow.Workflow.WorkflowTypeId, requestWorkflow.Workflow.Guid );
             }
@@ -2332,7 +2335,7 @@ namespace RockWeb.Blocks.Connection
             // When the script is executed, it is also removed from the client load event to ensure that it is only run once.
             string script;
 
-            if ( string.IsNullOrEmpty( message ) )
+            if (string.IsNullOrEmpty( message ))
             {
                 // Open the workflow detail page.
                 script = $@"
@@ -2380,30 +2383,30 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
         protected void gRequestModalViewModeActivities_RowDataBound( object sender, GridViewRowEventArgs e )
         {
-            if ( e.Row.RowType != DataControlRowType.DataRow )
+            if (e.Row.RowType != DataControlRowType.DataRow)
             {
                 return;
             }
 
             var viewModel = e.Row.DataItem as ActivityViewModel;
 
-            if ( viewModel == null )
+            if (viewModel == null)
             {
                 return;
             }
 
-            if ( viewModel.OpportunityId.HasValue && viewModel.OpportunityId.Value == ConnectionOpportunityId )
+            if (viewModel.OpportunityId.HasValue && viewModel.OpportunityId.Value == ConnectionOpportunityId)
             {
                 e.Row.AddCssClass( "info" );
             }
 
-            if ( !viewModel.CanEdit )
+            if (!viewModel.CanEdit)
             {
                 var cellCount = e.Row.Cells.Count;
                 var lastCell = e.Row.Cells[cellCount - 1];
-                var lbDelete = ( lastCell.Controls.Count > 0 ? lastCell.Controls[0] : null ) as LinkButton;
+                var lbDelete = (lastCell.Controls.Count > 0 ? lastCell.Controls[0] : null) as LinkButton;
 
-                if ( lbDelete != null )
+                if (lbDelete != null)
                 {
                     lbDelete.Enabled = false;
                 }
@@ -2419,7 +2422,7 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = e.Row.DataItem as ActivityViewModel;
 
-            if ( viewModel == null || !viewModel.CanEdit )
+            if (viewModel == null || !viewModel.CanEdit)
             {
                 return;
             }
@@ -2437,13 +2440,49 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if ( viewModel == null || viewModel.ConnectionState == ConnectionState.Inactive || viewModel.ConnectionState == ConnectionState.Connected )
+            if (viewModel == null || viewModel.ConnectionState == ConnectionState.Inactive || viewModel.ConnectionState == ConnectionState.Connected)
             {
                 return false;
             }
 
             var connectionOpportunities = GetConnectionOpportunities();
             return connectionOpportunities != null && connectionOpportunities.Count > 1 && CanUserEditConnectionRequest();
+        }
+
+        /// <summary>
+        /// SECC: Performs check to see if the user can connect the request based on if
+        /// Safety and Security needs to approve the connection request.
+        /// </summary>
+        /// <returns></returns>
+        private bool CanUserConnect()
+        {
+            var connectionOpportunity = GetConnectionOpportunity();
+            connectionOpportunity.LoadAttributes();
+            var requiresSecurityToConnect = connectionOpportunity.GetAttributeValue( "SecurityToConnect" ).AsBooleanOrNull();
+
+            //does not require security check
+            if (!requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value)
+            {
+                return true;
+            }
+
+            var connectableStatuses = connectionOpportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
+                .Select( v => v.AsIntegerOrNull() )
+                .Where( v => v.HasValue )
+                .ToList();
+
+            // if no connectable statuses defined, skip
+            if (connectableStatuses.Count() == 0)
+            {
+                return true;
+            }
+
+            var connectionRequest = GetConnectionRequest();
+
+            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId ) || connectionRequest.ConnectionState == ConnectionState.Connected;
+
+
+
         }
 
         private bool CanUserEditConnectionRequest()
@@ -2454,17 +2493,17 @@ namespace RockWeb.Blocks.Connection
 
             var userCanEditConnectionRequest = false;
 
-            if ( connectionType != null && connectionType.EnableRequestSecurity && connectionRequest != null )
+            if (connectionType != null && connectionType.EnableRequestSecurity && connectionRequest != null)
             {
                 userCanEditConnectionRequest = connectionRequest.IsAuthorized( Authorization.EDIT, CurrentPerson );
             }
-            else if ( connectionOpportunity != null )
+            else if (connectionOpportunity != null)
             {
                 userCanEditConnectionRequest = connectionOpportunity.IsAuthorized( Authorization.EDIT, CurrentPerson );
             }
 
             // Grants edit access to those in the opportunity's connector groups
-            if ( !userCanEditConnectionRequest && CurrentPersonId.HasValue )
+            if (!userCanEditConnectionRequest && CurrentPersonId.HasValue)
             {
                 var qryConnectionOpportunityConnectorGroups = new ConnectionOpportunityConnectorGroupService( new RockContext() )
                     .Queryable()
@@ -2475,11 +2514,11 @@ namespace RockWeb.Blocks.Connection
                 // Grant edit access to any of those in a non campus-specific connector group
                 userCanEditConnectionRequest = qryConnectionOpportunityConnectorGroups
                     .Any( g =>
-                        ( campuses.Count == 1 || !g.CampusId.HasValue ) &&
+                        (campuses.Count == 1 || !g.CampusId.HasValue) &&
                         g.ConnectorGroup != null &&
                         g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId && m.GroupMemberStatus == GroupMemberStatus.Active ) );
 
-                if ( !userCanEditConnectionRequest )
+                if (!userCanEditConnectionRequest)
                 {
                     // If this is a new request, grant edit access to any connector group. Otherwise, match the request's campus to the corresponding campus-specific connector group
                     var groupCampuses = qryConnectionOpportunityConnectorGroups
@@ -2487,12 +2526,12 @@ namespace RockWeb.Blocks.Connection
                             g.ConnectorGroup != null &&
                             g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId ) );
 
-                    if ( connectionRequest != null )
+                    if (connectionRequest != null)
                     {
-                        groupCampuses = groupCampuses.Where( g => ( connectionRequest.Id == 0 || ( connectionRequest.CampusId.HasValue && g.CampusId == connectionRequest.CampusId.Value ) ) );
+                        groupCampuses = groupCampuses.Where( g => (connectionRequest.Id == 0 || (connectionRequest.CampusId.HasValue && g.CampusId == connectionRequest.CampusId.Value)) );
                     }
 
-                    foreach ( var groupCampus in groupCampuses )
+                    foreach (var groupCampus in groupCampuses)
                     {
                         userCanEditConnectionRequest = true;
                         break;
@@ -2519,7 +2558,7 @@ namespace RockWeb.Blocks.Connection
 
             var activityViewModelQuery = GetActivityViewModelQuery();
 
-            if ( ViewAllActivities )
+            if (ViewAllActivities)
             {
                 gRequestModalViewModeActivities.DataSource = activityViewModelQuery.ToList();
                 lbRequestModalViewModeShowAllActivities.Visible = false;
@@ -2555,7 +2594,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbRequestModalViewModeAddActivity_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -2572,7 +2611,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeAddActivityModeSave_Click( object sender, EventArgs e )
         {
-            if ( !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest() )
+            if (!ConnectionRequestId.HasValue || !CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -2582,7 +2621,7 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestActivityService( rockContext );
             var activity = isAddMode ? new ConnectionRequestActivity() : service.Get( CurrentActivityId.Value );
 
-            if ( activity == null )
+            if (activity == null)
             {
                 return;
             }
@@ -2593,7 +2632,7 @@ namespace RockWeb.Blocks.Connection
             activity.ConnectionActivityTypeId = ddlRequestModalViewModeAddActivityModeType.SelectedValue.AsInteger();
             activity.ConnectionOpportunityId = ConnectionOpportunityId;
 
-            if ( isAddMode )
+            if (isAddMode)
             {
                 service.Add( activity );
             }
@@ -2602,7 +2641,7 @@ namespace RockWeb.Blocks.Connection
             RequestModalViewModeSubMode = RequestModalViewModeSubMode_View;
             ShowRequestModal();
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -2619,7 +2658,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
         protected void gRequestModalViewModeActivities_Delete( object sender, RowEventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -2632,7 +2671,7 @@ namespace RockWeb.Blocks.Connection
             connectionRequestActivityService.DeleteRange( query );
             rockContext.SaveChanges();
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -2658,7 +2697,7 @@ namespace RockWeb.Blocks.Connection
         {
             var opportunityId = e.CommandArgument.ToString().AsIntegerOrNull();
 
-            if ( opportunityId.HasValue )
+            if (opportunityId.HasValue)
             {
                 ddlRequestModalViewModeTransferModeOpportunity.SetValue( opportunityId.ToString() );
             }
@@ -2678,7 +2717,7 @@ namespace RockWeb.Blocks.Connection
             cblSearchModalCampus.DataSource = CampusCache.All().Where( c => c.IsActive != false );
             cblSearchModalCampus.DataBind();
 
-            if ( request.CampusId.HasValue )
+            if (request.CampusId.HasValue)
             {
                 cblSearchModalCampus.SetValues( new List<string> { request.CampusId.Value.ToString() } );
             }
@@ -2699,15 +2738,15 @@ namespace RockWeb.Blocks.Connection
             phSearchModalAttributeFilters.Controls.Clear();
             var searchAttributes = GetSearchAttributes();
 
-            foreach ( var attribute in searchAttributes )
+            foreach (var attribute in searchAttributes)
             {
                 var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
 
-                if ( control != null )
+                if (control != null)
                 {
-                    if ( control is IRockControl )
+                    if (control is IRockControl)
                     {
-                        var rockControl = ( IRockControl ) control;
+                        var rockControl = (IRockControl) control;
                         rockControl.Label = attribute.Name;
                         rockControl.Help = attribute.Description;
                         phSearchModalAttributeFilters.Controls.Add( control );
@@ -2734,7 +2773,7 @@ namespace RockWeb.Blocks.Connection
             var rockContext = new RockContext();
             var connectionOpportunityID = ddlRequestModalViewModeTransferModeOpportunity.SelectedValue.AsIntegerOrNull();
             var connectionOpportunity = new ConnectionOpportunityService( rockContext ).Get( connectionOpportunityID.Value );
-            if ( connectionOpportunity != null )
+            if (connectionOpportunity != null)
             {
                 rbRequestModalViewModeTransferModeDefaultConnector.Text = "Default Connector for " + connectionOpportunity.Name;
             }
@@ -2749,7 +2788,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransferModeSearch_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -2778,19 +2817,19 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransferModeSave_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
 
-            using ( var rockContext = new RockContext() )
+            using (var rockContext = new RockContext())
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionActivityTypeService = new ConnectionActivityTypeService( rockContext );
                 var connectionRequestActivityService = new ConnectionRequestActivityService( rockContext );
 
                 var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
-                if ( connectionRequest != null )
+                if (connectionRequest != null)
                 {
                     int? newOpportunityId = ddlRequestModalViewModeTransferModeOpportunity.SelectedValueAsId();
                     int? sourceConnectorPersonAliasId = connectionRequest.ConnectorPersonAliasId;
@@ -2804,18 +2843,18 @@ namespace RockWeb.Blocks.Connection
                         .Select( t => t.Id )
                         .FirstOrDefault();
 
-                    if ( newOpportunityId.HasValue && transferredActivityId > 0 )
+                    if (newOpportunityId.HasValue && transferredActivityId > 0)
                     {
                         var newOpportunity = new ConnectionOpportunityService( rockContext ).Get( newOpportunityId.Value );
 
                         connectionRequest.ConnectionOpportunityId = newOpportunityId.Value;
-                        if ( newOpportunity.ShowStatusOnTransfer && ddlRequestModalViewModeTransferModeStatus.Visible )
+                        if (newOpportunity.ShowStatusOnTransfer && ddlRequestModalViewModeTransferModeStatus.Visible)
                         {
                             var newStatusId = ddlRequestModalViewModeTransferModeStatus.SelectedValueAsId();
                             connectionRequest.ConnectionStatusId = newStatusId.Value;
                         }
 
-                        if ( newOpportunity.ShowCampusOnTransfer && cpTransferCampus.Visible )
+                        if (newOpportunity.ShowCampusOnTransfer && cpTransferCampus.Visible)
                         {
                             connectionRequest.CampusId = cpTransferCampus.SelectedCampusId;
                         }
@@ -2825,13 +2864,13 @@ namespace RockWeb.Blocks.Connection
                         connectionRequest.AssignedGroupMemberStatus = null;
 
                         // assign the connector based on the selection
-                        if ( rbTRequestModalViewModeTransferModeCurrentConnector.Checked )
+                        if (rbTRequestModalViewModeTransferModeCurrentConnector.Checked)
                         {
                             // just leave the connector that they had
                         }
-                        else if ( rbRequestModalViewModeTransferModeDefaultConnector.Checked )
+                        else if (rbRequestModalViewModeTransferModeDefaultConnector.Checked)
                         {
-                            if ( newOpportunity != null )
+                            if (newOpportunity != null)
                             {
                                 connectionRequest.ConnectorPersonAliasId = newOpportunity.GetDefaultConnectorPersonAliasId( connectionRequest.CampusId );
                             }
@@ -2840,18 +2879,18 @@ namespace RockWeb.Blocks.Connection
                                 connectionRequest.ConnectorPersonAliasId = null;
                             }
                         }
-                        else if ( rbRequestModalViewModeTransferModeNoConnector.Checked )
+                        else if (rbRequestModalViewModeTransferModeNoConnector.Checked)
                         {
                             connectionRequest.ConnectorPersonAliasId = null;
                         }
-                        else if ( rbRequestModalViewModeTransferModeSelectConnector.Checked )
+                        else if (rbRequestModalViewModeTransferModeSelectConnector.Checked)
                         {
                             int? connectorPersonId = ddlRequestModalViewModeTransferModeOpportunityConnector.SelectedValue.AsIntegerOrNull();
                             int? connectorPersonAliasId = null;
-                            if ( connectorPersonId.HasValue )
+                            if (connectorPersonId.HasValue)
                             {
                                 var connectorPerson = new PersonService( rockContext ).Get( connectorPersonId.Value );
-                                if ( connectorPerson != null )
+                                if (connectorPerson != null)
                                 {
                                     connectorPersonAliasId = connectorPerson.PrimaryAliasId;
                                 }
@@ -2861,7 +2900,7 @@ namespace RockWeb.Blocks.Connection
                         }
 
                         // if the Opportunity and Connector haven't changed then don't transfer.
-                        if ( connectionRequest.ConnectionOpportunityId == sourceOpportunityId && connectionRequest.ConnectorPersonAliasId == sourceConnectorPersonAliasId )
+                        if (connectionRequest.ConnectionOpportunityId == sourceOpportunityId && connectionRequest.ConnectorPersonAliasId == sourceConnectorPersonAliasId)
                         {
                             nbTranferFailed.Visible = true;
                             return;
@@ -2879,7 +2918,7 @@ namespace RockWeb.Blocks.Connection
 
                         rockContext.SaveChanges();
 
-                        if ( ConnectionOpportunityId != connectionRequest.ConnectionOpportunityId )
+                        if (ConnectionOpportunityId != connectionRequest.ConnectionOpportunityId)
                         {
                             // Connection opportunity changed
                             ConnectionOpportunityId = connectionRequest.ConnectionOpportunityId;
@@ -2888,7 +2927,7 @@ namespace RockWeb.Blocks.Connection
                             LoadSettings();
                             BindUI();
                         }
-                        else if ( IsCardViewMode )
+                        else if (IsCardViewMode)
                         {
                             RefreshRequestCard();
                         }
@@ -2903,7 +2942,7 @@ namespace RockWeb.Blocks.Connection
                 }
             }
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -2942,27 +2981,27 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbSearchModalSearch_Click( object sender, EventArgs e )
         {
-            using ( var rockContext = new RockContext() )
+            using (var rockContext = new RockContext())
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
-                if ( connectionRequest != null &&
+                if (connectionRequest != null &&
                     connectionRequest.ConnectionOpportunity != null &&
-                    connectionRequest.ConnectionOpportunity.ConnectionType != null )
+                    connectionRequest.ConnectionOpportunity.ConnectionType != null)
                 {
                     var connectionOpportunityService = new ConnectionOpportunityService( rockContext );
                     var connectionTypeId = connectionRequest.ConnectionOpportunity.ConnectionTypeId;
 
                     var qrySearch = connectionOpportunityService.Queryable().Where( a => a.ConnectionTypeId == connectionTypeId && a.IsActive == true );
 
-                    if ( !string.IsNullOrWhiteSpace( tbSearchModalName.Text ) )
+                    if (!string.IsNullOrWhiteSpace( tbSearchModalName.Text ))
                     {
                         var searchTerms = tbSearchModalName.Text.ToLower().SplitDelimitedValues( true );
                         qrySearch = qrySearch.Where( o => searchTerms.Any( t => t.Contains( o.Name.ToLower() ) || o.Name.ToLower().Contains( t ) ) );
                     }
 
                     var searchCampuses = cblSearchModalCampus.SelectedValuesAsInt;
-                    if ( searchCampuses.Count > 0 )
+                    if (searchCampuses.Count > 0)
                     {
                         qrySearch = qrySearch.Where( o => o.ConnectionOpportunityCampuses.Any( c => searchCampuses.Contains( c.CampusId ) ) );
                     }
@@ -2970,9 +3009,9 @@ namespace RockWeb.Blocks.Connection
                     // Filter query by any configured attribute filters
                     var searchAttributes = GetSearchAttributes();
 
-                    if ( searchAttributes != null && searchAttributes.Any() )
+                    if (searchAttributes != null && searchAttributes.Any())
                     {
-                        foreach ( var attribute in searchAttributes )
+                        foreach (var attribute in searchAttributes)
                         {
                             var filterControl = phSearchModalAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
                             qrySearch = attribute.FieldType.Field.ApplyAttributeQueryFilter( qrySearch, filterControl, attribute, connectionRequestService, Rock.Reporting.FilterMode.SimpleFilter );
@@ -3008,7 +3047,7 @@ namespace RockWeb.Blocks.Connection
                 "Unassigned" :
                 viewModel.ConnectorPersonFullname;
 
-            if ( viewModel.ConnectorPersonAliasId.HasValue )
+            if (viewModel.ConnectorPersonAliasId.HasValue)
             {
                 lRequestModalViewModeConnectorProfilePhoto.Text = string.Format(
                     @"<div class=""board-card-photo mb-1"" style=""background-image: url( '{0}' );"" title=""{1} Profile Photo""></div>",
@@ -3057,7 +3096,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeEdit_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -3074,7 +3113,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransfer_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -3092,7 +3131,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestViewModeViewHistory_Click( object sender, EventArgs e )
         {
-            if ( !ConnectionRequestId.HasValue )
+            if (!ConnectionRequestId.HasValue)
             {
                 return;
             }
@@ -3101,7 +3140,7 @@ namespace RockWeb.Blocks.Connection
             var connectionRequestService = new ConnectionRequestService( rockContext );
             var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
 
-            if ( connectionRequest != null )
+            if (connectionRequest != null)
             {
                 NavigateToLinkedPage( AttributeKey.ConnectionRequestHistoryPage, new Dictionary<string, string> { { PageParameterKey.ConnectionRequestGuid, connectionRequest.Guid.ToString() } } );
             }
@@ -3114,7 +3153,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeConnect_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            if (!CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -3122,7 +3161,7 @@ namespace RockWeb.Blocks.Connection
             MarkRequestConnected();
             ShowRequestModal();
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -3141,7 +3180,7 @@ namespace RockWeb.Blocks.Connection
         {
             var newConnectorPersonAliasId = e.CommandArgument.ToStringSafe().AsIntegerOrNull();
 
-            if ( !newConnectorPersonAliasId.HasValue || !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest() )
+            if (!newConnectorPersonAliasId.HasValue || !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest())
             {
                 return;
             }
@@ -3150,12 +3189,12 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestService( rockContext );
             var request = service.Get( ConnectionRequestId.Value );
 
-            if ( request == null )
+            if (request == null)
             {
                 return;
             }
 
-            if ( newConnectorPersonAliasId.Value == 0 )
+            if (newConnectorPersonAliasId.Value == 0)
             {
                 request.ConnectorPersonAliasId = null;
             }
@@ -3166,7 +3205,7 @@ namespace RockWeb.Blocks.Connection
 
             rockContext.SaveChanges();
 
-            if ( request.ConnectorPersonAliasId.HasValue )
+            if (request.ConnectorPersonAliasId.HasValue)
             {
                 AddAssignedActivity();
                 BindRequestModalViewModeActivitiesGrid();
@@ -3176,7 +3215,7 @@ namespace RockWeb.Blocks.Connection
             BindModalViewModeBadges();
             BindModalViewModeConnectorOptions();
 
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 RefreshRequestCard();
             }
@@ -3202,7 +3241,7 @@ namespace RockWeb.Blocks.Connection
             lRequestModalViewModeRequirementsLabels.Text = string.Empty;
 
             // If the connect button will not be shown, then there is no need to show the requirements
-            if ( !request.CanConnect )
+            if (!request.CanConnect)
             {
                 cblRequestModalViewModeManualRequirements.Visible = false;
                 rcwRequestModalViewModeRequirements.Visible = false;
@@ -3215,13 +3254,13 @@ namespace RockWeb.Blocks.Connection
             cblRequestModalViewModeManualRequirements.Visible = true;
             var passedAllRequirements = true;
 
-            foreach ( var requirementResult in requirementsResults )
+            foreach (var requirementResult in requirementsResults)
             {
-                if ( requirementResult.GroupRequirement.GroupRequirementType.RequirementCheckType == RequirementCheckType.Manual )
+                if (requirementResult.GroupRequirement.GroupRequirementType.RequirementCheckType == RequirementCheckType.Manual)
                 {
                     var checkboxItem = new ListItem( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel, requirementResult.GroupRequirement.Id.ToString() );
 
-                    if ( string.IsNullOrEmpty( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel ) )
+                    if (string.IsNullOrEmpty( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel ))
                     {
                         checkboxItem.Text = requirementResult.GroupRequirement.GroupRequirementType.Name;
                     }
@@ -3235,19 +3274,19 @@ namespace RockWeb.Blocks.Connection
                     string labelType;
                     string labelTooltip;
 
-                    if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.Meets )
+                    if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.Meets)
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.PositiveLabel;
                         labelType = "success";
                     }
-                    else if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning )
+                    else if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning)
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.WarningLabel;
                         labelType = "warning";
                     }
                     else
                     {
-                        if ( requirementResult.GroupRequirement.MustMeetRequirementToAddMember )
+                        if (requirementResult.GroupRequirement.MustMeetRequirementToAddMember)
                         {
                             passedAllRequirements = false;
                             labelText = requirementResult.GroupRequirement.GroupRequirementType.NegativeLabel;
@@ -3260,12 +3299,12 @@ namespace RockWeb.Blocks.Connection
                         }
                     }
 
-                    if ( string.IsNullOrEmpty( labelText ) )
+                    if (string.IsNullOrEmpty( labelText ))
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.Name;
                     }
 
-                    if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning )
+                    if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning)
                     {
                         labelTooltip = requirementResult.RequirementWarningDateTime.HasValue
                             ? "Last Checked: " + requirementResult.RequirementWarningDateTime.Value.ToString( "g" )
@@ -3289,7 +3328,7 @@ namespace RockWeb.Blocks.Connection
 
             var requirementsWithErrors = requirementsResults.Where( a => a.MeetsGroupRequirement == MeetsGroupRequirement.Error ).ToList();
 
-            if ( requirementsWithErrors.Any() )
+            if (requirementsWithErrors.Any())
             {
                 var text = string.Format(
                     "An error occurred in one or more of the requirement calculations: <br /> {0}",
@@ -3311,7 +3350,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="System.Web.UI.WebControls.RepeaterItemEventArgs"/> instance containing the event data.</param>
         protected void rptConnnectionTypes_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
-            if ( e.Item.ItemType != ListItemType.Item && e.Item.ItemType != ListItemType.AlternatingItem )
+            if (e.Item.ItemType != ListItemType.Item && e.Item.ItemType != ListItemType.AlternatingItem)
             {
                 return;
             }
@@ -3438,7 +3477,7 @@ namespace RockWeb.Blocks.Connection
             SaveSettingByConnectionType( UserPreferenceKey.SortBy, value ?? string.Empty );
             ConnectionRequestViewModelSortProperty sortProperty;
 
-            if ( !value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ) )
+            if (!value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ))
             {
                 CurrentSortProperty = sortProperty;
             }
@@ -3539,7 +3578,7 @@ namespace RockWeb.Blocks.Connection
 
             var personId = LoadSettingByConnectionType( FilterKey.Requester ).AsIntegerOrNull();
 
-            if ( personId.HasValue )
+            if (personId.HasValue)
             {
                 var rockContext = new RockContext();
                 var personService = new PersonService( rockContext );
@@ -3560,7 +3599,7 @@ namespace RockWeb.Blocks.Connection
                 sdrpLastActivityDateRangeFilter.SelectedDateRange.End.HasValue ||
                 rcbPastDueOnly.Checked;
 
-            if ( hasFilter )
+            if (hasFilter)
             {
                 aFilterDrawerToggle.AddCssClass( "bg-warning" );
             }
@@ -3575,7 +3614,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindViewModeToggle()
         {
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 lbToggleViewMode.Text = @"<i class=""fa fa-list""></i> List";
             }
@@ -3593,7 +3632,7 @@ namespace RockWeb.Blocks.Connection
             var campuseViewModels = GetCampusViewModels();
 
             // If there is only 1 campus, then we don't show campus controls throughout Rock
-            if ( campuseViewModels.Count <= 1 )
+            if (campuseViewModels.Count <= 1)
             {
                 CampusId = null;
                 divCampusBtnGroup.Visible = false;
@@ -3620,11 +3659,11 @@ namespace RockWeb.Blocks.Connection
             var connectorViewModels = GetConnectors( false, CampusId, null )
                 .Where( cvm => cvm.PersonAliasId != CurrentPersonAliasId );
 
-            if ( !ConnectorPersonAliasId.HasValue )
+            if (!ConnectorPersonAliasId.HasValue)
             {
                 lConnectorText.Text = "All Connectors";
             }
-            else if ( ConnectorPersonAliasId == CurrentPersonAliasId )
+            else if (ConnectorPersonAliasId == CurrentPersonAliasId)
             {
                 lConnectorText.Text = "My Connections";
             }
@@ -3632,7 +3671,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var connector = connectorViewModels.FirstOrDefault( c => c.PersonAliasId == ConnectorPersonAliasId );
 
-                if ( connector != null )
+                if (connector != null)
                 {
                     lConnectorText.Text = string.Format( "Connector: {0}", connector.Fullname );
                 }
@@ -3652,7 +3691,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindSortOptions()
         {
-            switch ( CurrentSortProperty )
+            switch (CurrentSortProperty)
             {
                 case ConnectionRequestViewModelSortProperty.Requestor:
                 case ConnectionRequestViewModelSortProperty.RequestorDesc:
@@ -3696,7 +3735,7 @@ namespace RockWeb.Blocks.Connection
             var viewModels = GetConnectionTypeViewModels();
             var personAliasId = CurrentPersonAliasId;
 
-            if ( !personAliasId.HasValue )
+            if (!personAliasId.HasValue)
             {
                 return;
             }
@@ -3719,7 +3758,7 @@ namespace RockWeb.Blocks.Connection
                 .Where( co => favoriteIds.Contains( co.Id ) )
                 .ToList();
 
-            if ( favoriteConnectionOpportunities.Any() )
+            if (favoriteConnectionOpportunities.Any())
             {
                 rptFavoriteConnectionOpportunities.DataSource = favoriteConnectionOpportunities;
                 rptFavoriteConnectionOpportunities.DataBind();
@@ -3776,7 +3815,7 @@ namespace RockWeb.Blocks.Connection
             ddlCampaignConnectionItemsMultiple.Items.Clear();
 
             var campaignConnectionItemsPendingCount = new Dictionary<CampaignItem, int>();
-            foreach ( var campaignConnectionItem in campaignConnectionItems )
+            foreach (var campaignConnectionItem in campaignConnectionItems)
             {
                 int pendingCount = CampaignConnectionHelper.GetPendingConnectionCount( campaignConnectionItem, CurrentPerson );
                 campaignConnectionItemsPendingCount.AddOrIgnore( campaignConnectionItem, pendingCount );
@@ -3790,7 +3829,7 @@ namespace RockWeb.Blocks.Connection
             nbNumberOfRequests.Visible = true;
             mdAddCampaignRequests.SaveButtonText = "Assign";
 
-            if ( campaignConnectionItems.Count() == 0 )
+            if (campaignConnectionItems.Count() == 0)
             {
                 nbAddConnectionRequestsMessage.Text = "There are no campaigns available for you to request connections for.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = NotificationBoxType.Warning;
@@ -3800,7 +3839,7 @@ namespace RockWeb.Blocks.Connection
                 nbNumberOfRequests.Visible = false;
                 mdAddCampaignRequests.SaveButtonText = string.Empty;
             }
-            else if ( campaignConnectionItems.Count() == 1 )
+            else if (campaignConnectionItems.Count() == 1)
             {
                 var campaignConnectionItem = campaignConnectionItems[0];
                 lCampaignConnectionItemSingle.Visible = true;
@@ -3814,7 +3853,7 @@ namespace RockWeb.Blocks.Connection
                 ddlCampaignConnectionItemsMultiple.Visible = true;
             }
 
-            if ( campaignConnectionItems.Count > 0 )
+            if (campaignConnectionItems.Count > 0)
             {
                 var firstCampaignConnectionItem = campaignConnectionItems.First();
                 SetDefaultNumberOfRequests( firstCampaignConnectionItem.Guid, campaignConnectionItemsPendingCount.GetValueOrNull( firstCampaignConnectionItem ) ?? 0 );
@@ -3829,7 +3868,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="selectedCampaignConnectionItemGuid">The selected campaign connection item unique identifier.</param>
         private void SetDefaultNumberOfRequests( Guid? selectedCampaignConnectionItemGuid, int pendingCount )
         {
-            if ( !selectedCampaignConnectionItemGuid.HasValue )
+            if (!selectedCampaignConnectionItemGuid.HasValue)
             {
                 // shouldn't happen
                 return;
@@ -3849,29 +3888,29 @@ namespace RockWeb.Blocks.Connection
             // Check to see if the group member has any CampaignDailyLimit values defined.
             var currentPersonConnectorGroupMember = opportunityConnecterGroupQuery
                 .Select( s => s.ConnectorGroup ).SelectMany( g => g.Members )
-                .WhereAttributeValue( rockContext, av => ( av.Attribute.Key == "CampaignDailyLimit" ) && av.ValueAsNumeric > 0 )
+                .WhereAttributeValue( rockContext, av => (av.Attribute.Key == "CampaignDailyLimit") && av.ValueAsNumeric > 0 )
                 .FirstOrDefault( m => m.PersonId == this.CurrentPersonId.Value );
 
-            if ( currentPersonConnectorGroupMember != null )
+            if (currentPersonConnectorGroupMember != null)
             {
                 currentPersonConnectorGroupMember.LoadAttributes();
                 defaultDailyLimitAssigned = currentPersonConnectorGroupMember.GetAttributeValue( "CampaignDailyLimit" ).AsIntegerOrNull();
             }
 
-            if ( defaultDailyLimitAssigned == null && selectedCampaignConnectionItem.CreateConnectionRequestOption == CreateConnectionRequestOptions.AsNeeded )
+            if (defaultDailyLimitAssigned == null && selectedCampaignConnectionItem.CreateConnectionRequestOption == CreateConnectionRequestOptions.AsNeeded)
             {
                 defaultDailyLimitAssigned = selectedCampaignConnectionItem.DailyLimitAssigned;
             }
 
             var entitySetItemService = new EntitySetItemService( rockContext );
 
-            if ( pendingCount == 0 )
+            if (pendingCount == 0)
             {
                 nbAddConnectionRequestsMessage.Text = "There are no pending requests remaining.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
                 nbAddConnectionRequestsMessage.Visible = true;
             }
-            else if ( pendingCount < defaultDailyLimitAssigned )
+            else if (pendingCount < defaultDailyLimitAssigned)
             {
                 nbAddConnectionRequestsMessage.Text = string.Format( "There are only {0} pending requests remaining.", pendingCount );
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
@@ -3895,7 +3934,7 @@ namespace RockWeb.Blocks.Connection
         {
             // note if there is only one CampaignConnectionItem, ddlCampaignConnectionItemsMultiple will not be visible, but it is still the selected one, because there is only one
             var selectedCampaignConnectionItemGuid = ddlCampaignConnectionItemsMultiple.SelectedValue.AsGuidOrNull();
-            if ( !selectedCampaignConnectionItemGuid.HasValue )
+            if (!selectedCampaignConnectionItemGuid.HasValue)
             {
                 // shouldn't happen
                 return;
@@ -3904,7 +3943,7 @@ namespace RockWeb.Blocks.Connection
             var campaignConnectionItems = Rock.Web.SystemSettings.GetValue( CampaignConnectionKey.CAMPAIGN_CONNECTION_CONFIGURATION ).FromJsonOrNull<List<CampaignItem>>() ?? new List<CampaignItem>();
             var selectedCampaignConnectionItem = campaignConnectionItems.Where( a => a.Guid == selectedCampaignConnectionItemGuid.Value ).FirstOrDefault();
 
-            if ( selectedCampaignConnectionItem == null )
+            if (selectedCampaignConnectionItem == null)
             {
                 // shouldn't happen
                 return;
@@ -3914,7 +3953,7 @@ namespace RockWeb.Blocks.Connection
             numberOfRequests = nbNumberOfRequests.Text.AsInteger();
             CampaignConnectionHelper.AddConnectionRequestsForPerson( selectedCampaignConnectionItem, this.CurrentPerson, numberOfRequests, out numberOfRequestsRemaining );
 
-            if ( numberOfRequestsRemaining == numberOfRequests )
+            if (numberOfRequestsRemaining == numberOfRequests)
             {
                 nbAddConnectionRequestsMessage.Text = "Additional Requests are not available as this time.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
@@ -3933,7 +3972,7 @@ namespace RockWeb.Blocks.Connection
         protected void ddlCampaignConnectionItem_SelectedIndexChanged( object sender, EventArgs e )
         {
             var selectedCampaignConnectionItemGuid = ddlCampaignConnectionItemsMultiple.SelectedValue.AsGuidOrNull();
-            if ( !selectedCampaignConnectionItemGuid.HasValue )
+            if (!selectedCampaignConnectionItemGuid.HasValue)
             {
                 // shouldn't happen
                 return;
@@ -3972,12 +4011,12 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindUI()
         {
-            if ( !ConnectionOpportunityId.HasValue )
+            if (!ConnectionOpportunityId.HasValue)
             {
                 GetConnectionOpportunity();
             }
 
-            if ( !ConnectionOpportunityId.HasValue )
+            if (!ConnectionOpportunityId.HasValue)
             {
                 pnlView.Visible = false;
                 ShowError( "At least one connection opportunity is required before this block can be used" );
@@ -4006,7 +4045,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindBoardOrGrid()
         {
-            if ( IsCardViewMode )
+            if (IsCardViewMode)
             {
                 upnlBoardView.Visible = true;
                 upnlGridView.Visible = false;
@@ -4048,10 +4087,10 @@ namespace RockWeb.Blocks.Connection
         private void SetControlOnTransfer( ConnectionOpportunity connectionOpportunity, ConnectionRequest connectionRequest )
         {
             ddlRequestModalViewModeTransferModeStatus.Visible = connectionOpportunity.ShowStatusOnTransfer;
-            if ( connectionOpportunity.ShowStatusOnTransfer )
+            if (connectionOpportunity.ShowStatusOnTransfer)
             {
                 ddlRequestModalViewModeTransferModeStatus.Items.Clear();
-                foreach ( var status in connectionOpportunity.ConnectionType.ConnectionStatuses )
+                foreach (var status in connectionOpportunity.ConnectionType.ConnectionStatuses)
                 {
                     ddlRequestModalViewModeTransferModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString() ) );
                 }
@@ -4060,7 +4099,7 @@ namespace RockWeb.Blocks.Connection
             }
 
             cpTransferCampus.Visible = connectionOpportunity.ShowCampusOnTransfer;
-            if ( connectionOpportunity.ShowCampusOnTransfer )
+            if (connectionOpportunity.ShowCampusOnTransfer)
             {
                 cpTransferCampus.IncludeInactive = false;
                 cpTransferCampus.SetValue( connectionRequest.CampusId );
@@ -4079,23 +4118,23 @@ namespace RockWeb.Blocks.Connection
             ddlRequestModalViewModeTransferModeOpportunityConnector.Items.Clear();
             ddlRequestModalViewModeTransferModeOpportunityConnector.Items.Add( new ListItem() );
 
-            if ( connectionOpportunity != null )
+            if (connectionOpportunity != null)
             {
-                if ( connectionOpportunity.ConnectionType != null && connectionRequest != null )
+                if (connectionOpportunity.ConnectionType != null && connectionRequest != null)
                 {
-                    if ( setControl )
+                    if (setControl)
                     {
                         SetControlOnTransfer( connectionOpportunity, connectionRequest );
                     }
 
                     var campusId = connectionRequest.CampusId;
-                    if ( connectionOpportunity.ShowCampusOnTransfer )
+                    if (connectionOpportunity.ShowCampusOnTransfer)
                     {
                         campusId = cpTransferCampus.SelectedCampusId;
                     }
 
                     var connectionOpportunityConnectorPersonList = new ConnectionOpportunityConnectorGroupService( rockContext ).Queryable()
-                        .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id && ( !campusId.HasValue || !a.CampusId.HasValue || a.CampusId.Value == campusId.Value ) )
+                        .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id && (!campusId.HasValue || !a.CampusId.HasValue || a.CampusId.Value == campusId.Value) )
                         .SelectMany( a => a.ConnectorGroup.Members )
                         .Where( a => a.GroupMemberStatus == GroupMemberStatus.Active )
                         .Select( a => a.Person )
@@ -4106,7 +4145,7 @@ namespace RockWeb.Blocks.Connection
                 }
 
                 // Add the current person as possible connector
-                if ( CurrentPerson != null )
+                if (CurrentPerson != null)
                 {
                     connectors.AddOrIgnore( CurrentPerson.Id, CurrentPerson );
                 }
@@ -4122,27 +4161,27 @@ namespace RockWeb.Blocks.Connection
             }
 
             int? defaultConnectorPersonId = null;
-            if ( connectionRequest != null && connectionOpportunity != null )
+            if (connectionRequest != null && connectionOpportunity != null)
             {
                 defaultConnectorPersonId = connectionOpportunity.GetDefaultConnectorPersonId( connectionRequest.CampusId );
-                if ( defaultConnectorPersonId.HasValue )
+                if (defaultConnectorPersonId.HasValue)
                 {
                     var defaultConnectorListItem = ddlRequestModalViewModeTransferModeOpportunityConnector.Items.FindByValue( defaultConnectorPersonId.ToString() );
-                    if ( defaultConnectorListItem != null )
+                    if (defaultConnectorListItem != null)
                     {
                         defaultConnectorListItem.Attributes["IsDefaultConnector"] = true.ToTrueFalse();
                     }
                 }
             }
 
-            if ( rbRequestModalViewModeTransferModeDefaultConnector.Checked && connectionOpportunity != null )
+            if (rbRequestModalViewModeTransferModeDefaultConnector.Checked && connectionOpportunity != null)
             {
-                if ( defaultConnectorPersonId.HasValue )
+                if (defaultConnectorPersonId.HasValue)
                 {
                     ddlRequestModalViewModeTransferModeOpportunityConnector.SetValue( defaultConnectorPersonId.Value );
                 }
             }
-            else if ( connectionRequest != null && connectionRequest.ConnectorPersonAlias != null )
+            else if (connectionRequest != null && connectionRequest.ConnectorPersonAlias != null)
             {
                 ddlRequestModalViewModeTransferModeOpportunityConnector.SetValue( connectionRequest.ConnectorPersonAlias.PersonId );
             }
@@ -4216,7 +4255,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<GroupViewModel> GetAvailablePlacementGroups( int? campusId )
         {
-            if ( _availablePlacementGroups == null )
+            if (_availablePlacementGroups == null)
             {
                 var rockContext = new RockContext();
                 var opportunity = GetConnectionOpportunity();
@@ -4274,7 +4313,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private CampusCache GetCampus()
         {
-            if ( CampusId.HasValue )
+            if (CampusId.HasValue)
             {
                 return CampusCache.Get( CampusId.Value );
             }
@@ -4289,7 +4328,7 @@ namespace RockWeb.Blocks.Connection
         {
             HideRequestModalNotification();
 
-            if ( !ConnectionRequestId.HasValue )
+            if (!ConnectionRequestId.HasValue)
             {
                 return;
             }
@@ -4306,7 +4345,7 @@ namespace RockWeb.Blocks.Connection
                 .Include( cr => cr.AssignedGroup )
                 .FirstOrDefault( cr => cr.Id == ConnectionRequestId.Value );
 
-            if ( connectionRequest == null || connectionRequest.PersonAlias == null || connectionRequest.ConnectionOpportunity == null )
+            if (connectionRequest == null || connectionRequest.PersonAlias == null || connectionRequest.ConnectionOpportunity == null)
             {
                 return;
             }
@@ -4315,13 +4354,13 @@ namespace RockWeb.Blocks.Connection
             GroupMember groupMember = null;
 
             // Only do group member placement if the request has an assigned placement group, role, and status
-            if ( connectionRequest.AssignedGroupId.HasValue &&
+            if (connectionRequest.AssignedGroupId.HasValue &&
                 connectionRequest.AssignedGroupMemberRoleId.HasValue &&
-                connectionRequest.AssignedGroupMemberStatus.HasValue )
+                connectionRequest.AssignedGroupMemberStatus.HasValue)
             {
                 var group = connectionRequest.AssignedGroup;
 
-                if ( group != null )
+                if (group != null)
                 {
                     // Only attempt the add if person does not already exist in group with same role
                     groupMember = groupMemberService.GetByGroupIdAndPersonIdAndGroupRoleId(
@@ -4329,7 +4368,7 @@ namespace RockWeb.Blocks.Connection
                         connectionRequest.PersonAlias.PersonId,
                         connectionRequest.AssignedGroupMemberRoleId.Value );
 
-                    if ( groupMember == null )
+                    if (groupMember == null)
                     {
                         groupMember = new GroupMember();
                         groupMember.PersonId = connectionRequest.PersonAlias.PersonId;
@@ -4338,13 +4377,13 @@ namespace RockWeb.Blocks.Connection
                         groupMember.GroupMemberStatus = connectionRequest.AssignedGroupMemberStatus.Value;
                         var groupRequirementLookup = group.GetGroupRequirements( rockContext ).ToList().ToDictionary( k => k.Id );
 
-                        foreach ( ListItem item in cblRequestModalViewModeManualRequirements.Items )
+                        foreach (ListItem item in cblRequestModalViewModeManualRequirements.Items)
                         {
                             var groupRequirementId = item.Value.AsInteger();
                             var groupRequirement = groupRequirementLookup[groupRequirementId];
 
-                            if ( !item.Selected &&
-                                ( groupRequirement == null || groupRequirement.MustMeetRequirementToAddMember ) )
+                            if (!item.Selected &&
+                                (groupRequirement == null || groupRequirement.MustMeetRequirementToAddMember))
                             {
                                 okToConnect = false;
                                 ShowRequestModalNotification(
@@ -4363,16 +4402,16 @@ namespace RockWeb.Blocks.Connection
                             }
                         }
 
-                        if ( okToConnect )
+                        if (okToConnect)
                         {
                             groupMemberService.Add( groupMember );
-                            if ( !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ) )
+                            if (!string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ))
                             {
                                 var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( connectionRequest.AssignedGroupMemberAttributeValues );
-                                if ( savedValues != null )
+                                if (savedValues != null)
                                 {
                                     groupMember.LoadAttributes();
-                                    foreach ( var item in savedValues )
+                                    foreach (var item in savedValues)
                                     {
                                         groupMember.SetAttributeValue( item.Key, item.Value );
                                     }
@@ -4383,7 +4422,7 @@ namespace RockWeb.Blocks.Connection
                 }
             }
 
-            if ( okToConnect )
+            if (okToConnect)
             {
                 // ... but always record the connection activity and change the state to connected.
                 var guid = Rock.SystemGuid.ConnectionActivityType.CONNECTED.AsGuid();
@@ -4392,7 +4431,7 @@ namespace RockWeb.Blocks.Connection
                     .Select( t => t.Id )
                     .FirstOrDefault();
 
-                if ( connectedActivityId > 0 )
+                if (connectedActivityId > 0)
                 {
                     var connectionRequestActivity = new ConnectionRequestActivity();
                     connectionRequestActivity.ConnectionRequestId = connectionRequest.Id;
@@ -4406,7 +4445,7 @@ namespace RockWeb.Blocks.Connection
 
                 rockContext.SaveChanges();
 
-                if ( groupMember != null && !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ) )
+                if (groupMember != null && !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ))
                 {
                     groupMember.SaveAttributeValues( rockContext );
                 }
@@ -4418,25 +4457,25 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void DeleteRequest()
         {
-            if ( !ConnectionRequestId.HasValue )
+            if (!ConnectionRequestId.HasValue)
             {
                 return;
             }
 
-            using ( var rockContext = new RockContext() )
+            using (var rockContext = new RockContext())
             {
                 var service = new ConnectionRequestService( rockContext );
                 var connectionRequest = service.Get( ConnectionRequestId.Value );
-                if ( connectionRequest != null )
+                if (connectionRequest != null)
                 {
                     string errorMessage;
-                    if ( !service.CanDelete( connectionRequest, out errorMessage ) )
+                    if (!service.CanDelete( connectionRequest, out errorMessage ))
                     {
                         ShowError( errorMessage );
                         return;
                     }
 
-                    if ( !service.IsAuthorizedToEdit( connectionRequest, CurrentPerson ) )
+                    if (!service.IsAuthorizedToEdit( connectionRequest, CurrentPerson ))
                     {
                         ShowError( "You are not authorized to delete this Connection Request." );
                         return;
@@ -4460,14 +4499,14 @@ namespace RockWeb.Blocks.Connection
         /// </returns>
         private bool CanEdit()
         {
-            if ( UserCanEdit )
+            if (UserCanEdit)
             {
                 return true;
             }
 
             var opportunity = GetConnectionOpportunity();
 
-            if ( opportunity == null )
+            if (opportunity == null)
             {
                 return false;
             }
@@ -4489,7 +4528,7 @@ namespace RockWeb.Blocks.Connection
             var connectionOpportunityIdParam = PageParameter( PageParameterKey.ConnectionOpportunityId ).AsIntegerOrNull();
             var campusIdParam = PageParameter( PageParameterKey.CampusId ).AsIntegerOrNull();
 
-            if ( !ConnectionOpportunityId.HasValue && connectionRequestIdParam.HasValue )
+            if (!ConnectionOpportunityId.HasValue && connectionRequestIdParam.HasValue)
             {
                 var rockContext = new RockContext();
                 var connectionRequestService = new ConnectionRequestService( rockContext );
@@ -4503,7 +4542,7 @@ namespace RockWeb.Blocks.Connection
                     } )
                     .FirstOrDefault();
 
-                if ( result != null && availableOpportunityIds.Contains( result.ConnectionOpportunityId ) )
+                if (result != null && availableOpportunityIds.Contains( result.ConnectionOpportunityId ))
                 {
                     ConnectionOpportunityId = result.ConnectionOpportunityId;
                     ConnectionRequestId = connectionRequestIdParam.Value;
@@ -4515,27 +4554,27 @@ namespace RockWeb.Blocks.Connection
             }
 
             // If the opportunity is not yet set by the request id param, then set it
-            if ( !ConnectionOpportunityId.HasValue &&
+            if (!ConnectionOpportunityId.HasValue &&
                 connectionOpportunityIdParam.HasValue &&
-                availableOpportunityIds.Contains( connectionOpportunityIdParam.Value ) )
+                availableOpportunityIds.Contains( connectionOpportunityIdParam.Value ))
             {
                 ConnectionOpportunityId = connectionOpportunityIdParam.Value;
                 ConnectionRequestId = null;
                 ViewAllActivities = false;
                 IsRequestModalAddEditMode = false;
                 RequestModalViewModeSubMode = RequestModalViewModeSubMode_View;
-                if ( campusIdParam.HasValue )
+                if (campusIdParam.HasValue)
                 {
                     SaveSettingByConnectionType( UserPreferenceKey.CampusFilter, campusIdParam.ToString() );
                 }
             }
 
             // If the opportunity is not yet set by the request or opportunity id params, then set it from preference
-            if ( !ConnectionOpportunityId.HasValue )
+            if (!ConnectionOpportunityId.HasValue)
             {
                 var userPreferenceOpportunityId = GetBlockUserPreference( UserPreferenceKey.ConnectionOpportunityId ).AsIntegerOrNull();
 
-                if ( userPreferenceOpportunityId.HasValue && availableOpportunityIds.Contains( userPreferenceOpportunityId.Value ) )
+                if (userPreferenceOpportunityId.HasValue && availableOpportunityIds.Contains( userPreferenceOpportunityId.Value ))
                 {
                     ConnectionOpportunityId = userPreferenceOpportunityId;
                 }
@@ -4551,7 +4590,7 @@ namespace RockWeb.Blocks.Connection
             // Load the sort property
             ConnectionRequestViewModelSortProperty sortProperty;
 
-            if ( Enum.TryParse( LoadSettingByConnectionType( UserPreferenceKey.SortBy ), out sortProperty ) )
+            if (Enum.TryParse( LoadSettingByConnectionType( UserPreferenceKey.SortBy ), out sortProperty ))
             {
                 CurrentSortProperty = sortProperty;
             }
@@ -4576,7 +4615,7 @@ namespace RockWeb.Blocks.Connection
         {
             var key = GetKeyForSettingByConnectionType( subKey );
 
-            if ( key.IsNullOrWhiteSpace() )
+            if (key.IsNullOrWhiteSpace())
             {
                 return string.Empty;
             }
@@ -4594,7 +4633,7 @@ namespace RockWeb.Blocks.Connection
         {
             var key = GetKeyForSettingByConnectionType( subKey );
 
-            if ( key.IsNullOrWhiteSpace() )
+            if (key.IsNullOrWhiteSpace())
             {
                 return;
             }
@@ -4611,7 +4650,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if ( connectionOpportunity == null )
+            if (connectionOpportunity == null)
             {
                 return string.Empty;
             }
@@ -4643,13 +4682,13 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private ConnectionRequestActivity GetCurrentActivity()
         {
-            if ( !CurrentActivityId.HasValue )
+            if (!CurrentActivityId.HasValue)
             {
                 _connectionRequestActivity = null;
                 return null;
             }
 
-            if ( _connectionRequestActivity != null && _connectionRequestActivity.Id == CurrentActivityId )
+            if (_connectionRequestActivity != null && _connectionRequestActivity.Id == CurrentActivityId)
             {
                 return _connectionRequestActivity;
             }
@@ -4669,12 +4708,12 @@ namespace RockWeb.Blocks.Connection
         private ConnectionRequestViewModel GetConnectionRequestViewModel()
         {
             // Do not make a db call if the id and current record are in sync
-            if ( _connectionRequestViewModel != null && _connectionRequestViewModel.Id == ConnectionRequestId )
+            if (_connectionRequestViewModel != null && _connectionRequestViewModel.Id == ConnectionRequestId)
             {
                 return _connectionRequestViewModel;
             }
 
-            if ( !ConnectionRequestId.HasValue )
+            if (!ConnectionRequestId.HasValue)
             {
                 _connectionRequestViewModel = null;
                 return _connectionRequestViewModel;
@@ -4700,13 +4739,13 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if ( viewModel == null )
+            if (viewModel == null)
             {
                 _requesterPerson = null;
                 return null;
             }
 
-            if ( _requesterPerson != null && _requesterPerson.Id == viewModel.PersonId )
+            if (_requesterPerson != null && _requesterPerson.Id == viewModel.PersonId)
             {
                 return _requesterPerson;
             }
@@ -4726,12 +4765,12 @@ namespace RockWeb.Blocks.Connection
         private ConnectionRequest GetConnectionRequest()
         {
             // Do not make a db call if the id and current record are in sync
-            if ( _connectionRequest != null && _connectionRequest.Id == ConnectionRequestId )
+            if (_connectionRequest != null && _connectionRequest.Id == ConnectionRequestId)
             {
                 return _connectionRequest;
             }
 
-            if ( !ConnectionRequestId.HasValue )
+            if (!ConnectionRequestId.HasValue)
             {
                 _connectionRequest = null;
                 return _connectionRequest;
@@ -4762,7 +4801,7 @@ namespace RockWeb.Blocks.Connection
         private ConnectionOpportunity GetConnectionOpportunity()
         {
             // Do not make a db call if the id and current record are in sync
-            if ( _connectionOpportunity != null && _connectionOpportunity.Id == ConnectionOpportunityId )
+            if (_connectionOpportunity != null && _connectionOpportunity.Id == ConnectionOpportunityId)
             {
                 return _connectionOpportunity;
             }
@@ -4787,7 +4826,7 @@ namespace RockWeb.Blocks.Connection
                 query.FirstOrDefault();
 
             // Select the first record if one is not explicitly selected
-            if ( !ConnectionOpportunityId.HasValue && _connectionOpportunity != null )
+            if (!ConnectionOpportunityId.HasValue && _connectionOpportunity != null)
             {
                 ConnectionOpportunityId = _connectionOpportunity.Id;
                 ConnectionRequestId = null;
@@ -4805,7 +4844,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<ConnectionTypeViewModel> GetConnectionTypeViewModels()
         {
-            if ( _connectionTypeViewModels == null )
+            if (_connectionTypeViewModels == null)
             {
                 var rockContext = new RockContext();
                 var connectionTypeService = new ConnectionTypeService( rockContext );
@@ -4815,7 +4854,7 @@ namespace RockWeb.Blocks.Connection
                     .Include( ct => ct.ConnectionOpportunities )
                     .Where( ct => ct.IsActive );
 
-                if ( typeGuidsFilter.Any() )
+                if (typeGuidsFilter.Any())
                 {
                     query = query.Where( ct => typeGuidsFilter.Contains( ct.Guid ) );
                 }
@@ -4868,7 +4907,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if ( connectionOpportunity == null )
+            if (connectionOpportunity == null)
             {
                 return new List<ConnectionOpportunityViewModel>();
             }
@@ -4876,7 +4915,7 @@ namespace RockWeb.Blocks.Connection
             var connectionTypes = GetConnectionTypeViewModels();
             var connectionType = connectionTypes.FirstOrDefault( ct => ct.Id == connectionOpportunity.ConnectionTypeId );
 
-            if ( connectionType == null )
+            if (connectionType == null)
             {
                 return new List<ConnectionOpportunityViewModel>();
             }
@@ -4912,7 +4951,7 @@ namespace RockWeb.Blocks.Connection
                 } )
                 .ToList();
 
-            if ( includeCurrentPerson && CurrentPersonAliasId.HasValue && !connectors.Any( c => c.PersonAliasId == CurrentPersonAliasId ) )
+            if (includeCurrentPerson && CurrentPersonAliasId.HasValue && !connectors.Any( c => c.PersonAliasId == CurrentPersonAliasId ))
             {
                 connectors.Add( new ConnectorViewModel
                 {
@@ -4922,12 +4961,12 @@ namespace RockWeb.Blocks.Connection
                 } );
             }
 
-            if ( personAliasIdToInclude.HasValue && !connectors.Any( c => c.PersonAliasId == personAliasIdToInclude ) )
+            if (personAliasIdToInclude.HasValue && !connectors.Any( c => c.PersonAliasId == personAliasIdToInclude ))
             {
                 var personAliasService = new PersonAliasService( rockContext );
                 var person = personAliasService.GetPerson( personAliasIdToInclude.Value );
 
-                if ( person != null )
+                if (person != null)
                 {
                     connectors.Add( new ConnectorViewModel
                     {
@@ -4954,7 +4993,7 @@ namespace RockWeb.Blocks.Connection
             var requesterPersonAliasId = ppRequesterFilter.PersonAliasId;
             var statuses = cblStatusFilter.SelectedValuesAsInt;
             var states = cblStateFilter.SelectedValues
-                .Select( s => ( ConnectionState ) Enum.Parse( typeof( ConnectionState ), s ) )
+                .Select( s => (ConnectionState) Enum.Parse( typeof( ConnectionState ), s ) )
                 .ToList();
             var activityTypeIds = cblLastActivityFilter.SelectedValuesAsInt;
 
@@ -4984,15 +5023,15 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if ( connectionOpportunity == null )
+            if (connectionOpportunity == null)
             {
                 _connectionActivityTypes = null;
                 return null;
             }
 
-            if ( _connectionActivityTypes != null &&
+            if (_connectionActivityTypes != null &&
                 _connectionActivityTypes.Any() &&
-                _connectionActivityTypes.FirstOrDefault().ConnectionTypeId == connectionOpportunity.ConnectionTypeId )
+                _connectionActivityTypes.FirstOrDefault().ConnectionTypeId == connectionOpportunity.ConnectionTypeId)
             {
                 return _connectionActivityTypes;
             }
@@ -5021,20 +5060,20 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private Rock.Model.Group GetPlacementGroup( int? groupId )
         {
-            if ( !groupId.HasValue )
+            if (!groupId.HasValue)
             {
                 return null;
             }
 
             var group = _placementGroups.GetValueOrNull( groupId.Value );
 
-            if ( group == null )
+            if (group == null)
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
                 group = groupService.GetNoTracking( groupId.Value );
 
-                if ( group != null )
+                if (group != null)
                 {
                     _placementGroups[groupId.Value] = group;
                 }
@@ -5072,7 +5111,7 @@ namespace RockWeb.Blocks.Connection
             // Parse the attribute filters
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if ( connectionOpportunity == null )
+            if (connectionOpportunity == null)
             {
                 return new List<AttributeCache>();
             }
@@ -5115,7 +5154,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionRequestViewModel = GetConnectionRequestViewModel();
 
-            if ( connectionRequestViewModel == null )
+            if (connectionRequestViewModel == null)
             {
                 return new List<ActivityViewModel>().AsQueryable();
             }
@@ -5127,7 +5166,7 @@ namespace RockWeb.Blocks.Connection
                 .AsNoTracking()
                 .Where( a => a.ConnectionRequest.PersonAliasId == connectionRequestViewModel.PersonAliasId );
 
-            if ( connectionType.EnableFullActivityList )
+            if (connectionType.EnableFullActivityList)
             {
                 query = query.Where( a => a.ConnectionOpportunity.ConnectionTypeId == connectionType.Id );
             }
@@ -5164,7 +5203,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionType = GetConnectionType();
 
-            if ( connectionType == null )
+            if (connectionType == null)
             {
                 return new List<ConnectionActivityType>().AsQueryable();
             }
@@ -5184,7 +5223,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<PersonGroupRequirementStatus> GetGroupRequirementStatuses( ConnectionRequestViewModel request )
         {
-            if ( request == null || !request.PlacementGroupId.HasValue )
+            if (request == null || !request.PlacementGroupId.HasValue)
             {
                 return new List<PersonGroupRequirementStatus>();
             }
@@ -5193,14 +5232,14 @@ namespace RockWeb.Blocks.Connection
             var key = string.Format( "{0}-{1}", request.PersonId, groupId );
             var requirementsResults = _groupRequirementStatuses.GetValueOrNull( key );
 
-            if ( requirementsResults != null )
+            if (requirementsResults != null)
             {
                 return requirementsResults.ToList();
             }
 
             var group = GetPlacementGroup( groupId );
 
-            if ( group == null )
+            if (group == null)
             {
                 requirementsResults = new List<PersonGroupRequirementStatus>();
             }
@@ -5209,7 +5248,7 @@ namespace RockWeb.Blocks.Connection
                 var rockContext = new RockContext();
                 requirementsResults = group.PersonMeetsGroupRequirements( rockContext, request.PersonId, request.PlacementGroupRoleId );
 
-                if ( requirementsResults != null )
+                if (requirementsResults != null)
                 {
                     // Ignore the NotApplicable requirements.
                     requirementsResults = requirementsResults.Where( r => r.MeetsGroupRequirement != MeetsGroupRequirement.NotApplicable );
@@ -5339,7 +5378,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( string value )
         {
-            if ( value == null )
+            if (value == null)
             {
                 return "null";
             }
@@ -5353,7 +5392,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( DateTime? value )
         {
-            if ( !value.HasValue )
+            if (!value.HasValue)
             {
                 return "null";
             }
@@ -5367,7 +5406,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( int? value )
         {
-            if ( !value.HasValue )
+            if (!value.HasValue)
             {
                 return "null";
             }
@@ -5381,7 +5420,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The values.</param>
         private string ToJavaScript( List<int> values )
         {
-            if ( values == null )
+            if (values == null)
             {
                 return "null";
             }
@@ -5395,7 +5434,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( bool? value )
         {
-            if ( !value.HasValue )
+            if (!value.HasValue)
             {
                 return "null";
             }
@@ -5409,7 +5448,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The values.</param>
         private string ToJavaScript( List<string> values )
         {
-            if ( values == null )
+            if (values == null)
             {
                 return "null";
             }

--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -348,7 +348,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var currentValue = ConnectionOpportunityId;
 
-                if (currentValue != value)
+                if ( currentValue != value )
                 {
                     ViewState["ConnectionOpportunityId"] = value;
                     SetBlockUserPreference( UserPreferenceKey.ConnectionOpportunityId, value.ToStringSafe() );
@@ -427,7 +427,7 @@ namespace RockWeb.Blocks.Connection
         {
             get
             {
-                if (OnlyShowAssigned())
+                if ( OnlyShowAssigned() )
                 {
                     return CurrentPersonAliasId;
                 }
@@ -450,7 +450,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var valueToReturn = ViewState["IsCardViewMode"].ToStringSafe().AsBooleanOrNull();
 
-                if (!valueToReturn.HasValue)
+                if ( !valueToReturn.HasValue )
                 {
                     var connectionType = GetConnectionType();
                     valueToReturn = connectionType == null ?
@@ -498,7 +498,7 @@ namespace RockWeb.Blocks.Connection
                 var value = ViewState["CurrentSortProperty"].ToStringSafe();
                 ConnectionRequestViewModelSortProperty sortProperty;
 
-                if (!value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ))
+                if ( !value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ) )
                 {
                     return sortProperty;
                 }
@@ -550,7 +550,7 @@ namespace RockWeb.Blocks.Connection
             // Configure the badge types
             var delimitedBadgeGuids = GetAttributeValue( AttributeKey.Badges );
 
-            if (delimitedBadgeGuids.IsNullOrWhiteSpace())
+            if ( delimitedBadgeGuids.IsNullOrWhiteSpace() )
             {
                 pnlRequestModalViewModeBadges.Visible = false;
                 return;
@@ -577,7 +577,7 @@ namespace RockWeb.Blocks.Connection
         {
             base.OnLoad( e );
 
-            if (!Page.IsPostBack)
+            if ( !Page.IsPostBack )
             {
                 LoadSettings();
                 BindUI();
@@ -587,13 +587,13 @@ namespace RockWeb.Blocks.Connection
                 var causingControlClientId = Request["__EVENTTARGET"].ToStringSafe();
                 var causingControl = Page.FindControl( causingControlClientId );
 
-                if (causingControlClientId == lbJavaScriptCommand.ClientID)
+                if ( causingControlClientId == lbJavaScriptCommand.ClientID )
                 {
                     // Handle card commands that are sent via JavaScript
                     ProcessJavaScriptCommand();
                 }
-                else if (causingControl != null &&
-                    (causingControl == ppRequesterFilter || causingControl.Parent == ppRequesterFilter))
+                else if ( causingControl != null &&
+                    ( causingControl == ppRequesterFilter || causingControl.Parent == ppRequesterFilter ) )
                 {
                     // If the postback comes from the filter drawer, don't modify the filter drawer CSS,
                     // which dictates if the drawer is open or closed
@@ -631,21 +631,21 @@ namespace RockWeb.Blocks.Connection
             int? newIndex;
             ParseDragEventArgument( argument, out action, out newStatusId, out requestId, out newIndex );
 
-            if (action == "on-following-change")
+            if ( action == "on-following-change" )
             {
                 BindFavoriteConnectionOpportunities();
                 BindConnectionTypesRepeater();
                 return;
             }
 
-            if (!requestId.HasValue)
+            if ( !requestId.HasValue )
             {
                 return;
             }
 
             ConnectionRequestId = requestId.Value;
 
-            if (action == "view")
+            if ( action == "view" )
             {
                 ViewAllActivities = false;
                 IsRequestModalAddEditMode = false;
@@ -654,16 +654,16 @@ namespace RockWeb.Blocks.Connection
                 return;
             }
 
-            if (action == "connect")
+            if ( action == "connect" )
             {
                 MarkRequestConnected();
                 RefreshRequestCard();
                 return;
             }
 
-            if (action == "card-drop-confirmed")
+            if ( action == "card-drop-confirmed" )
             {
-                if (newStatusId.HasValue && newIndex.HasValue)
+                if ( newStatusId.HasValue && newIndex.HasValue )
                 {
                     ProcessConfirmedDragEvent( newStatusId.Value, newIndex.Value );
                 }
@@ -683,7 +683,7 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestService( rockContext );
             var request = service.Get( ConnectionRequestId.Value );
 
-            if (request == null)
+            if ( request == null )
             {
                 return;
             }
@@ -693,9 +693,9 @@ namespace RockWeb.Blocks.Connection
             rockContext.SaveChanges();
 
             // Reordering is only allowed when the cards are sorted by order
-            if (CurrentSortProperty == ConnectionRequestViewModelSortProperty.Order)
+            if ( CurrentSortProperty == ConnectionRequestViewModelSortProperty.Order )
             {
-                if (request.ConnectionStatusId == newStatusId)
+                if ( request.ConnectionStatusId == newStatusId )
                 {
                     var requestsOfStatus = service.Queryable()
                     .Where( r =>
@@ -714,9 +714,9 @@ namespace RockWeb.Blocks.Connection
                     var orderValues = requestsOfStatus.Select( r => r.Order ).ToList();
                     var previousValue = -1;
 
-                    for (var i = 0; i < orderValues.Count; i++)
+                    for ( var i = 0; i < orderValues.Count; i++ )
                     {
-                        if (orderValues[i] <= previousValue)
+                        if ( orderValues[i] <= previousValue )
                         {
                             orderValues[i] = previousValue + 1;
                         }
@@ -727,12 +727,12 @@ namespace RockWeb.Blocks.Connection
                     requestsOfStatus.Remove( request );
                     requestsOfStatus.Insert( newIndex, request );
 
-                    for (var i = 0; i < orderValues.Count; i++)
+                    for ( var i = 0; i < orderValues.Count; i++ )
                     {
                         requestsOfStatus[i].Order = orderValues[i];
                     }
 
-                    if (orderValues.Count < requestsOfStatus.Count)
+                    if ( orderValues.Count < requestsOfStatus.Count )
                     {
                         // This happens if the card came from another column. The remove did nothing, but
                         // we added the new request. Therefore we need to set the last request to the
@@ -778,7 +778,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private string GetEmailLinkMarkup( int? personId, string emailAddress )
         {
-            if (!personId.HasValue || emailAddress.IsNullOrWhiteSpace())
+            if ( !personId.HasValue || emailAddress.IsNullOrWhiteSpace() )
             {
                 return string.Empty;
             }
@@ -792,13 +792,13 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private string GetStatusIconHtml( ConnectionRequestViewModel viewModel )
         {
-            if (viewModel == null)
+            if ( viewModel == null )
             {
                 return string.Empty;
             }
 
             var connectionType = GetConnectionType();
-            var daysUntilRequestIdle = connectionType == null ? (int?) null : connectionType.DaysUntilRequestIdle;
+            var daysUntilRequestIdle = connectionType == null ? ( int? ) null : connectionType.DaysUntilRequestIdle;
             var connectionRequestStatusIconTemplate = GetAttributeValue( AttributeKey.ConnectionRequestStatusIconsTemplate );
             var mergeFields = new Dictionary<string, object>();
 
@@ -810,7 +810,7 @@ namespace RockWeb.Blocks.Connection
                 viewModel.IsUnassigned
             };
 
-            if (LavaService.RockLiquidIsEnabled)
+            if ( LavaService.RockLiquidIsEnabled )
             {
                 mergeFields.Add( "ConnectionRequestStatusIcons", DotLiquid.Hash.FromAnonymousObject( connectionRequestStatusIcons ) );
             }
@@ -833,7 +833,7 @@ namespace RockWeb.Blocks.Connection
             var connectionRequest = GetConnectionRequest();
             var requesterPerson = GetRequesterPerson();
 
-            if (viewModel == null || connectionRequest == null || requesterPerson == null)
+            if ( viewModel == null || connectionRequest == null || requesterPerson == null )
             {
                 return;
             }
@@ -862,6 +862,7 @@ namespace RockWeb.Blocks.Connection
             lRequestModalViewModeEmail.Text = GetEmailLinkMarkup( viewModel.PersonId, viewModel.PersonEmail );
             aRequestModalViewModeProfileLink.Attributes["href"] = string.Format( "/person/{0}", viewModel.PersonId );
             btnRequestModalViewModeTransfer.Visible = DoShowTransferButton();
+
             /* 
                 08/09/2022 - SK
                 This is special case where we are not using viewModel.CanConnect in order to make this align with older ConnectionRequestDetail block.
@@ -875,7 +876,6 @@ namespace RockWeb.Blocks.Connection
                 connectionRequest.ConnectionOpportunity.ShowConnectButton &&
                 CanUserEditConnectionRequest() &&
                 CanUserConnect();
-
             btnRequestModalViewModeEdit.Visible = CanUserEditConnectionRequest();
             lbRequestModalViewModeAddActivity.Visible = CanUserEditConnectionRequest();
             rRequestModalViewModeConnectorSelect.Visible = CanUserEditConnectionRequest();
@@ -887,7 +887,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var smsLinkHtml = string.Empty;
 
-                if (hasSmsLink && p.IsMessagingEnabled)
+                if ( hasSmsLink && p.IsMessagingEnabled )
                 {
                     var smsLink = LinkedPageUrl(
                         AttributeKey.SmsLinkPage,
@@ -909,7 +909,7 @@ namespace RockWeb.Blocks.Connection
             // Build the description list on the right side
             var rightDescList = new DescriptionList();
 
-            if (viewModel.DateOpened.HasValue)
+            if ( viewModel.DateOpened.HasValue )
             {
                 rightDescList.Add(
                     "Request Date",
@@ -919,7 +919,7 @@ namespace RockWeb.Blocks.Connection
             // Placement group HTML
             var placementGroupHtml = string.Empty;
 
-            if (viewModel.GroupName.IsNullOrWhiteSpace())
+            if ( viewModel.GroupName.IsNullOrWhiteSpace() )
             {
                 placementGroupHtml = "None Assigned";
             }
@@ -934,7 +934,7 @@ namespace RockWeb.Blocks.Connection
 
                 placementGroupHtml = string.Format( "<a href=\"{0}\">{1}</a>", groupDetailPageUrl, viewModel.GroupName );
 
-                if (viewModel.PlacementGroupRoleId.HasValue)
+                if ( viewModel.PlacementGroupRoleId.HasValue )
                 {
                     var rockContext = new RockContext();
                     var service = new GroupTypeRoleService( rockContext );
@@ -943,7 +943,7 @@ namespace RockWeb.Blocks.Connection
                     var roleName = role != null ? role.Name : string.Empty;
                     var statusName = viewModel.PlacementGroupMemberStatus.ConvertToStringSafe();
 
-                    if (!string.IsNullOrWhiteSpace( roleName ) || !string.IsNullOrWhiteSpace( statusName ))
+                    if ( !string.IsNullOrWhiteSpace( roleName ) || !string.IsNullOrWhiteSpace( statusName ) )
                     {
                         placementGroupHtml += string.Format(
                             " ({0}{1}{2})",
@@ -952,7 +952,7 @@ namespace RockWeb.Blocks.Connection
                             roleName );
                     }
 
-                    if (viewModel.PlacementGroupId.HasValue)
+                    if ( viewModel.PlacementGroupId.HasValue )
                     {
                         var groupMember = new GroupMember();
                         groupMember.Group = connectionRequest.AssignedGroup;
@@ -963,12 +963,12 @@ namespace RockWeb.Blocks.Connection
 
                         groupMember.LoadAttributes();
 
-                        if (connectionRequest.AssignedGroupMemberAttributeValues.IsNotNullOrWhiteSpace())
+                        if ( connectionRequest.AssignedGroupMemberAttributeValues.IsNotNullOrWhiteSpace() )
                         {
                             var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( connectionRequest.AssignedGroupMemberAttributeValues );
-                            if (savedValues != null)
+                            if ( savedValues != null )
                             {
-                                foreach (var item in savedValues)
+                                foreach ( var item in savedValues )
                                 {
                                     groupMember.SetAttributeValue( item.Key, item.Value );
                                 }
@@ -1003,7 +1003,7 @@ namespace RockWeb.Blocks.Connection
             BindModalViewModeConnectorOptions();
 
             // Render the current view mode for the modal (activities grid or add activity form)
-            if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_AddEditActivity)
+            if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_AddEditActivity )
             {
                 var activity = GetCurrentActivity();
                 var connectorPersonAliasId = activity == null ? null : activity.ConnectorPersonAliasId;
@@ -1023,10 +1023,10 @@ namespace RockWeb.Blocks.Connection
                 BindConnectorOptions( ddlRequestModalViewModeAddActivityModeConnector, true, viewModel.CampusId, connectorPersonAliasId );
 
                 // Bind edit mode if appropriate
-                if (activity != null)
+                if ( activity != null )
                 {
                     tbRequestModalViewModeAddActivityModeNote.Text = activity.Note;
-                    ddlRequestModalViewModeAddActivityModeConnector.SelectedValue = (connectorPersonAliasId ?? 0).ToStringSafe();
+                    ddlRequestModalViewModeAddActivityModeConnector.SelectedValue = ( connectorPersonAliasId ?? 0 ).ToStringSafe();
                     ddlRequestModalViewModeAddActivityModeType.SelectedValue = activity.ConnectionActivityTypeId.ToString();
                 }
                 else
@@ -1035,7 +1035,7 @@ namespace RockWeb.Blocks.Connection
                     tbRequestModalViewModeAddActivityModeNote.Text = string.Empty;
                 }
             }
-            else if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_View)
+            else if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_View )
             {
                 divRequestModalViewModeAddActivityMode.Visible = false;
                 divRequestModalViewModeActivityGridMode.Visible = true;
@@ -1044,8 +1044,8 @@ namespace RockWeb.Blocks.Connection
                 BindRequestModalViewModeActivitiesGrid();
                 BindRequestModalViewModeWorkflowsGrid();
             }
-            else if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_Transfer ||
-                RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch)
+            else if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_Transfer ||
+                RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch )
             {
                 divRequestModalViewModeAddActivityMode.Visible = false;
                 divRequestModalViewModeActivityGridMode.Visible = false;
@@ -1055,7 +1055,7 @@ namespace RockWeb.Blocks.Connection
                 ddlRequestModalViewModeTransferModeStatus.Items.Clear();
                 var statuses = GetConnectionType().ConnectionStatuses;
 
-                foreach (var status in statuses)
+                foreach ( var status in statuses )
                 {
                     ddlRequestModalViewModeTransferModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString() ) );
                 }
@@ -1069,7 +1069,7 @@ namespace RockWeb.Blocks.Connection
                 ddlRequestModalViewModeTransferModeOpportunity.Items.Clear();
                 var opportunities = GetConnectionOpportunities();
 
-                foreach (var opportunity in opportunities.OrderBy( o => o.Order ).ThenBy( o => o.Name ))
+                foreach ( var opportunity in opportunities.OrderBy( o => o.Order ).ThenBy( o => o.Name ) )
                 {
                     ddlRequestModalViewModeTransferModeOpportunity.Items.Add( new ListItem( opportunity.Name, opportunity.Id.ToString().ToUpper() ) );
                     hasOriginalOpportunity |= opportunity.Id == originalTargetOpportunityId;
@@ -1085,7 +1085,7 @@ namespace RockWeb.Blocks.Connection
                     "Current Connector: {0}",
                     viewModel.ConnectorPersonFullname.IsNullOrWhiteSpace() ? "No Connector" : viewModel.ConnectorPersonFullname );
 
-                if (hasOriginalOpportunity)
+                if ( hasOriginalOpportunity )
                 {
                     ddlRequestModalViewModeTransferModeOpportunity.SetValue( originalTargetOpportunityId ?? viewModel.ConnectionOpportunityId );
                 }
@@ -1096,7 +1096,7 @@ namespace RockWeb.Blocks.Connection
 
                 ddlRequestModalViewModeTransferModeOpportunity_SelectedIndexChanged( null, null );
 
-                if (RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch)
+                if ( RequestModalViewModeSubMode == RequestModalViewModeSubMode_TransferSearch )
                 {
                     ShowSearchModal();
                 }
@@ -1110,7 +1110,7 @@ namespace RockWeb.Blocks.Connection
             mdRequest.SubTitle = GetRequestDetailModalHeaderLabelMarkup();
 
             // Show group requirement issues if any
-            if (viewModel.PlacementGroupId.HasValue)
+            if ( viewModel.PlacementGroupId.HasValue )
             {
                 pnlRequestModalViewModeRequirements.Visible = true;
                 ShowRequestModalViewModeRequirementsStatuses();
@@ -1131,7 +1131,7 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if (viewModel == null)
+            if ( viewModel == null )
             {
                 return string.Empty;
             }
@@ -1139,7 +1139,7 @@ namespace RockWeb.Blocks.Connection
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine( @"<div class=""panel-labels"" style=""text-align: right;"">" );
 
-            if (!viewModel.CampusName.IsNullOrWhiteSpace())
+            if ( !viewModel.CampusName.IsNullOrWhiteSpace() )
             {
                 stringBuilder.AppendLine( GetLabelMarkup( "campus", viewModel.CampusName ) );
             }
@@ -1201,13 +1201,13 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void ShowRequestModal()
         {
-            if (IsRequestModalAddMode())
+            if ( IsRequestModalAddMode() )
             {
                 divRequestModalAddEditMode.Visible = true;
                 divRequestModalViewMode.Visible = false;
                 BindRequestModalAddEditMode();
             }
-            else if (IsRequestModalEditMode())
+            else if ( IsRequestModalEditMode() )
             {
                 divRequestModalAddEditMode.Visible = true;
                 divRequestModalViewMode.Visible = false;
@@ -1236,7 +1236,7 @@ namespace RockWeb.Blocks.Connection
         {
             HideRequestModalNotification();
 
-            if (IsRequestModalAddMode())
+            if ( IsRequestModalAddMode() )
             {
                 mdRequest.Hide();
             }
@@ -1254,7 +1254,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbRequestModalAddEditModeSave_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -1276,11 +1276,18 @@ namespace RockWeb.Blocks.Connection
 
             var state = rblRequestModalAddEditModeState.SelectedValueAsEnumOrNull<ConnectionState>();
 
+            // ROCK-8640: prevent unauthorized users from transitioning a request into Connected state.
+            // If the selected state is Connected but the user isn't authorized, preserve the existing state.
+            if ( state == ConnectionState.Connected && !CanUserConnect() )
+            {
+                state = connectionRequest.ConnectionState;
+            }
+
             // If a value is selected in the radio button list, use it, otherwise use "Active".
             // This prevents the "FutureFollowUp" State from remaining on a Connection Request if the Connection Type's "Enable Future Follow-up" was unchecked.
-            if (state.HasValue)
+            if ( state.HasValue )
             {
-                connectionRequest.ConnectionState = rblRequestModalAddEditModeState.SelectedValueAsEnum<ConnectionState>();
+                connectionRequest.ConnectionState = state.Value;
             }
             else
             {
@@ -1295,7 +1302,7 @@ namespace RockWeb.Blocks.Connection
             connectionRequest.Comments = tbRequestModalAddEditModeComments.Text.SanitizeHtml();
 
             // If this request is a Future FollowUp state, use the selected date from the date picker, otherwise it should be null.
-            if (connectionRequest.ConnectionState == ConnectionState.FutureFollowUp)
+            if ( connectionRequest.ConnectionState == ConnectionState.FutureFollowUp )
             {
                 connectionRequest.FollowupDate = dpRequestModalAddEditModeFollowUp.SelectedDate;
             }
@@ -1311,7 +1318,7 @@ namespace RockWeb.Blocks.Connection
             // So, make sure a message is displayed in the validation summary.
             cvRequestModalCustomValidator.IsValid = connectionRequest.IsValid;
 
-            if (!cvRequestModalCustomValidator.IsValid)
+            if ( !cvRequestModalCustomValidator.IsValid )
             {
                 cvRequestModalCustomValidator.ErrorMessage = connectionRequest.ValidationResults
                     .Select( a => a.ErrorMessage )
@@ -1320,7 +1327,7 @@ namespace RockWeb.Blocks.Connection
                 return;
             }
 
-            if (isAddMode)
+            if ( isAddMode )
             {
                 connectionRequestService.Add( connectionRequest );
             }
@@ -1334,14 +1341,14 @@ namespace RockWeb.Blocks.Connection
             _connectionRequest = connectionRequest;
 
             // Add an activity that the connector was assigned (or changed)
-            if (originalConnectorPersonAliasId != newConnectorPersonAliasId)
+            if ( originalConnectorPersonAliasId != newConnectorPersonAliasId )
             {
                 AddAssignedActivity();
             }
 
             BindUI();
 
-            if (isAddMode)
+            if ( isAddMode )
             {
                 // Return to the board or grid
                 ConnectionRequestId = connectionRequest.Id;
@@ -1354,7 +1361,7 @@ namespace RockWeb.Blocks.Connection
                 ShowRequestModal();
             }
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -1371,14 +1378,14 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if (viewModel == null || !viewModel.ConnectorPersonAliasId.HasValue)
+            if ( viewModel == null || !viewModel.ConnectorPersonAliasId.HasValue )
             {
                 return;
             }
 
             var rockContext = new RockContext();
 
-            if (_assignedActivityId == 0)
+            if ( _assignedActivityId == 0 )
             {
                 var guid = Rock.SystemGuid.ConnectionActivityType.ASSIGNED.AsGuid();
                 _assignedActivityId = new ConnectionActivityTypeService( rockContext ).Queryable()
@@ -1388,7 +1395,7 @@ namespace RockWeb.Blocks.Connection
                     .FirstOrDefault();
             }
 
-            if (_assignedActivityId > 0)
+            if ( _assignedActivityId > 0 )
             {
                 var connectionRequestActivityService = new ConnectionRequestActivityService( rockContext );
                 var connectionRequestActivity = new ConnectionRequestActivity
@@ -1413,13 +1420,13 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
         protected void ppRequestModalAddEditModePerson_SelectPerson( object sender, EventArgs e )
         {
-            if (!ppRequestModalAddEditModePerson.PersonId.HasValue)
+            if ( !ppRequestModalAddEditModePerson.PersonId.HasValue )
             {
                 CheckRequestModalAddEditModeGroupRequirements();
                 return;
             }
 
-            using (var rockContext = new RockContext())
+            using ( var rockContext = new RockContext() )
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionOpportunity = GetConnectionOpportunity();
@@ -1430,10 +1437,10 @@ namespace RockWeb.Blocks.Connection
                     .Where( r =>
                         r.PersonAliasId == ppRequestModalAddEditModePerson.PersonAliasId.Value &&
                         r.ConnectionOpportunityId == connectionOpportunity.Id &&
-                        (r.ConnectionState == ConnectionState.Active || r.ConnectionState == ConnectionState.FutureFollowUp) )
+                        ( r.ConnectionState == ConnectionState.Active || r.ConnectionState == ConnectionState.FutureFollowUp ) )
                     .Any();
 
-                if (hasRequest)
+                if ( hasRequest )
                 {
                     var text = string.Format(
                         "There is already an active (or future follow up) request in the '{0}' opportunity for {1}.",
@@ -1460,16 +1467,16 @@ namespace RockWeb.Blocks.Connection
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt();
             var roleId = ddlRequestModalAddEditModePlacementRole.SelectedValueAsInt();
 
-            if (!personId.HasValue || !groupId.HasValue || !roleId.HasValue)
+            if ( !personId.HasValue || !groupId.HasValue || !roleId.HasValue )
             {
                 return;
             }
 
-            using (var rockContext = new RockContext())
+            using ( var rockContext = new RockContext() )
             {
                 var group = new GroupService( rockContext ).Get( groupId.Value );
 
-                if (group == null)
+                if ( group == null )
                 {
                     return;
                 }
@@ -1479,7 +1486,7 @@ namespace RockWeb.Blocks.Connection
                     personId.Value,
                     roleId.Value );
 
-                if (requirementsResults != null && requirementsResults
+                if ( requirementsResults != null && requirementsResults
                     .Any( r =>
                     r.GroupRequirement.MustMeetRequirementToAddMember &&
                     r.MeetsGroupRequirement == MeetsGroupRequirement.NotMet &&
@@ -1487,7 +1494,7 @@ namespace RockWeb.Blocks.Connection
                     )
                 {
                     var person = new PersonService( rockContext ).Get( personId.Value );
-                    if (person != null)
+                    if ( person != null )
                     {
                         var text = string.Format(
                             "{0} does not currently meet the requirements for the selected group/role and will not be able to be placed.",
@@ -1529,12 +1536,12 @@ namespace RockWeb.Blocks.Connection
             BindConnectorOptions( ddlRequestModalAddEditModeConnector, true, campusId, connectorPersonAliasId );
             ddlRequestModalAddEditModeConnector.SetValue( connectorPersonAliasId );
 
-            if (connectorPersonAliasId == 0)
+            if ( connectorPersonAliasId == 0 )
             {
                 // Select the default connector for the campus
                 var connectionOpportunity = GetConnectionOpportunity();
 
-                if (connectionOpportunity != null)
+                if ( connectionOpportunity != null )
                 {
                     var defaultConnectorPersonAliasId = connectionOpportunity.GetDefaultConnectorPersonAliasId( campusId );
                     ddlRequestModalAddEditModeConnector.SetValue( defaultConnectorPersonAliasId );
@@ -1560,7 +1567,7 @@ namespace RockWeb.Blocks.Connection
             var groups = GetAvailablePlacementGroups( campusId );
 
             // Add the currently assigned group if it hasn't been added already
-            if (viewModel != null && viewModel.PlacementGroupId.HasValue && !groups.Any( g => g.Id == viewModel.PlacementGroupId ))
+            if ( viewModel != null && viewModel.PlacementGroupId.HasValue && !groups.Any( g => g.Id == viewModel.PlacementGroupId ) )
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1576,13 +1583,13 @@ namespace RockWeb.Blocks.Connection
                     } )
                     .FirstOrDefault();
 
-                if (currentGroup != null)
+                if ( currentGroup != null )
                 {
                     groups.Add( currentGroup );
                 }
             }
 
-            foreach (var g in groups.OrderBy( g => g.Name ).ThenBy( g => g.Id ))
+            foreach ( var g in groups.OrderBy( g => g.Name ).ThenBy( g => g.Id ) )
             {
                 var text = string.Format(
                     "{0} ({1})",
@@ -1614,7 +1621,7 @@ namespace RockWeb.Blocks.Connection
             var isFutureFollowUp = !rblRequestModalAddEditModeState.SelectedValue.IsNullOrWhiteSpace() &&
                 rblRequestModalAddEditModeState.SelectedValueAsEnum<ConnectionState>() == ConnectionState.FutureFollowUp;
 
-            if (isFutureFollowUp)
+            if ( isFutureFollowUp )
             {
                 dpRequestModalAddEditModeFollowUp.Visible = true;
                 dpRequestModalAddEditModeFollowUp.Required = true;
@@ -1653,7 +1660,7 @@ namespace RockWeb.Blocks.Connection
             var requestGroupId = request != null ? request.PlacementGroupId : null;
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt() ?? requestGroupId;
 
-            if (groupId.HasValue)
+            if ( groupId.HasValue )
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1678,7 +1685,7 @@ namespace RockWeb.Blocks.Connection
                     .ToList()
                     .Distinct();
 
-                foreach (var role in roles)
+                foreach ( var role in roles )
                 {
                     var listItem = new ListItem( role.RoleName, role.RoleId.ToString() );
                     listItem.Selected = currentRoleId.HasValue && currentRoleId.Value == role.RoleId;
@@ -1705,7 +1712,7 @@ namespace RockWeb.Blocks.Connection
             var groupId = ddlRequestModalAddEditModePlacementGroup.SelectedValueAsInt();
             var roleId = ddlRequestModalAddEditModePlacementRole.SelectedValueAsInt();
 
-            if (groupId.HasValue && roleId.HasValue)
+            if ( groupId.HasValue && roleId.HasValue )
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
@@ -1726,9 +1733,9 @@ namespace RockWeb.Blocks.Connection
                     .ToList()
                     .Distinct();
 
-                foreach (var status in statuses)
+                foreach ( var status in statuses )
                 {
-                    var intValue = (int) status;
+                    var intValue = ( int ) status;
                     var listItem = new ListItem( status.ToString(), intValue.ToString() );
                     listItem.Selected = currentStatus.HasValue && currentStatus.Value.ConvertToInt() == intValue;
                     ddlRequestModalAddEditModePlacementStatus.Items.Add( listItem );
@@ -1750,7 +1757,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="setValues">if set to <c>true</c> [set values].</param>
         private void BuildRequestModalAddEditModeGroupMemberAttributes( int? groupId, int? groupMemberRoleId, GroupMemberStatus? groupMemberStatus, bool setValues )
         {
-            if (!groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue)
+            if ( !groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue )
             {
                 avcRequestModalAddEditModeGroupMember.AddEditControls( null, true );
                 return;
@@ -1766,12 +1773,12 @@ namespace RockWeb.Blocks.Connection
             groupMember.LoadAttributes();
             var request = GetConnectionRequest();
 
-            if (request != null && !request.AssignedGroupMemberAttributeValues.IsNullOrWhiteSpace())
+            if ( request != null && !request.AssignedGroupMemberAttributeValues.IsNullOrWhiteSpace() )
             {
                 var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( request.AssignedGroupMemberAttributeValues );
-                if (savedValues != null)
+                if ( savedValues != null )
                 {
-                    foreach (var item in savedValues)
+                    foreach ( var item in savedValues )
                     {
                         groupMember.SetAttributeValue( item.Key, item.Value );
                     }
@@ -1796,7 +1803,7 @@ namespace RockWeb.Blocks.Connection
 
             var values = new Dictionary<string, string>();
 
-            if (!groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue)
+            if ( !groupId.HasValue || !groupMemberRoleId.HasValue || !groupMemberStatus.HasValue )
             {
                 return string.Empty;
             }
@@ -1811,7 +1818,7 @@ namespace RockWeb.Blocks.Connection
             groupMember.LoadAttributes();
             avcRequestModalAddEditModeGroupMember.GetEditValues( groupMember );
 
-            foreach (var attrValue in groupMember.AttributeValues)
+            foreach ( var attrValue in groupMember.AttributeValues )
             {
                 values.Add( attrValue.Key, attrValue.Value.Value );
             }
@@ -1826,7 +1833,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbAddRequest_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -1849,20 +1856,18 @@ namespace RockWeb.Blocks.Connection
             var connectionType = GetConnectionType();
 
             BindConnectorOptions( ddlRequestModalAddEditModeConnector, true, campusId, connectorPersonAliasId );
-            List<ConnectionState> ignoredConnectionTypes = new List<ConnectionState>();
+
+            ConnectionState[] ignoredConnectionTypes = { };
 
             // If this Connection Type does not allow Future Follow-Up, ignore it from the ConnectionState types.
-            if (!connectionType.EnableFutureFollowup)
+            if ( !connectionType.EnableFutureFollowup )
             {
-                ignoredConnectionTypes.Add( ConnectionState.FutureFollowUp );
+                ignoredConnectionTypes = new ConnectionState[] { ConnectionState.FutureFollowUp };
             }
 
-            if (!CanUserConnect())
-            {
-                ignoredConnectionTypes.Add( ConnectionState.Connected );
-            }
             // Ignore binding the Connection Types that are in the provided array.
-            rblRequestModalAddEditModeState.BindToEnum( ignoreTypes: ignoredConnectionTypes.ToArray() );
+            rblRequestModalAddEditModeState.BindToEnum( ignoreTypes: ignoredConnectionTypes );
+
             // Status
             rblRequestModalAddEditModeStatus.Items.Clear();
             var allStatuses = connectionType.ConnectionStatuses
@@ -1870,16 +1875,16 @@ namespace RockWeb.Blocks.Connection
                 .ThenByDescending( cs => cs.IsDefault )
                 .ThenBy( cs => cs.Name );
 
-            foreach (var status in allStatuses)
+            foreach ( var status in allStatuses )
             {
                 // Add Status to selection list only if marked as active or currently selected.
-                if (status.IsActive)
+                if ( status.IsActive )
                 {
                     rblRequestModalAddEditModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString().ToUpper() ) );
                 }
             }
 
-            if (viewModel != null)
+            if ( viewModel != null )
             {
                 var rockContext = new RockContext();
                 var personService = new PersonService( rockContext );
@@ -1888,12 +1893,12 @@ namespace RockWeb.Blocks.Connection
                 ppRequestModalAddEditModePerson.SetValue( requestor );
                 ddlRequestModalAddEditModeConnector.SetValue( connectorPersonAliasId );
 
-                rblRequestModalAddEditModeState.SetValue( (int) viewModel.ConnectionState );
+                rblRequestModalAddEditModeState.SetValue( ( int ) viewModel.ConnectionState );
                 tbRequestModalAddEditModeComments.Text = viewModel.Comments;
                 rblRequestModalAddEditModeStatus.SetValue( viewModel.StatusId );
                 ddlRequestModalAddEditModePlacementGroup.SetValue( viewModel.PlacementGroupId );
                 ddlRequestModalAddEditModePlacementRole.SetValue( viewModel.PlacementGroupRoleId );
-                ddlRequestModalAddEditModePlacementStatus.SetValue( (int?) viewModel.PlacementGroupMemberStatus );
+                ddlRequestModalAddEditModePlacementStatus.SetValue( ( int? ) viewModel.PlacementGroupMemberStatus );
                 dpRequestModalAddEditModeFollowUp.SelectedDate = viewModel.FollowupDate;
             }
             else
@@ -1904,7 +1909,7 @@ namespace RockWeb.Blocks.Connection
                 // Clear controls and set defaults
                 var defaultStatus = allStatuses.FirstOrDefault( s => s.IsDefault );
 
-                if (defaultStatus != null)
+                if ( defaultStatus != null )
                 {
                     rblRequestModalAddEditModeStatus.SetValue( defaultStatus.Id );
                 }
@@ -1920,7 +1925,7 @@ namespace RockWeb.Blocks.Connection
 
                 var connectionOpportunity = GetConnectionOpportunity();
 
-                if (connectionOpportunity != null)
+                if ( connectionOpportunity != null )
                 {
                     var defaultConnectorPersonAliasId = connectionOpportunity.GetDefaultConnectorPersonAliasId( campusId );
                     ddlRequestModalAddEditModeConnector.SetValue( defaultConnectorPersonAliasId );
@@ -1955,7 +1960,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if (connectionOpportunity == null)
+            if ( connectionOpportunity == null )
             {
                 return;
             }
@@ -1969,15 +1974,15 @@ namespace RockWeb.Blocks.Connection
                 .Distinct();
 
             var authorizedWorkflows = new List<ConnectionWorkflow>();
-            foreach (var manualWorkflow in manualWorkflows)
+            foreach ( var manualWorkflow in manualWorkflows )
             {
-                if ((manualWorkflow.WorkflowType.IsActive ?? true) && manualWorkflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ))
+                if ( ( manualWorkflow.WorkflowType.IsActive ?? true ) && manualWorkflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ) )
                 {
                     authorizedWorkflows.Add( manualWorkflow );
                 }
             }
 
-            if (authorizedWorkflows.Any())
+            if ( authorizedWorkflows.Any() )
             {
                 divRequestModalViewModeWorkflows.Visible = true;
                 rptRequestWorkflows.DataSource = authorizedWorkflows.ToList();
@@ -1998,7 +2003,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionWorkflowId = e.CommandArgument.ToStringSafe().AsInteger();
 
-            if (e.CommandName != "LaunchWorkflow" || connectionWorkflowId == 0 || !ConnectionRequestId.HasValue)
+            if ( e.CommandName != "LaunchWorkflow" || connectionWorkflowId == 0 || !ConnectionRequestId.HasValue )
             {
                 return;
             }
@@ -2009,21 +2014,21 @@ namespace RockWeb.Blocks.Connection
             var connectionWorkflowService = new ConnectionWorkflowService( rockContext );
             var connectionWorkflow = connectionWorkflowService.Get( connectionWorkflowId );
 
-            if (connectionWorkflow == null || connectionRequest == null)
+            if ( connectionWorkflow == null || connectionRequest == null )
             {
                 return;
             }
 
             var workflowType = connectionWorkflow.WorkflowTypeCache;
 
-            if (workflowType == null || workflowType.IsActive == false)
+            if ( workflowType == null || workflowType.IsActive == false )
             {
                 return;
             }
 
             var workflow = Workflow.Activate( workflowType, connectionWorkflow.WorkflowType.WorkTerm, rockContext );
 
-            if (workflow == null)
+            if ( workflow == null )
             {
                 return;
             }
@@ -2031,9 +2036,9 @@ namespace RockWeb.Blocks.Connection
             var workflowService = new WorkflowService( rockContext );
             List<string> workflowErrors;
 
-            if (workflowService.Process( workflow, connectionRequest, out workflowErrors ))
+            if ( workflowService.Process( workflow, connectionRequest, out workflowErrors ) )
             {
-                if (workflow.Id != 0)
+                if ( workflow.Id != 0 )
                 {
                     new ConnectionRequestWorkflowService( rockContext ).Add( new ConnectionRequestWorkflow
                     {
@@ -2046,7 +2051,7 @@ namespace RockWeb.Blocks.Connection
 
                     rockContext.SaveChanges();
 
-                    if (workflow.HasActiveEntryForm( CurrentPerson ))
+                    if ( workflow.HasActiveEntryForm( CurrentPerson ) )
                     {
                         var message = $"A '{workflowType.Name}' workflow has been started.<br><br>The new workflow has an active form that is ready for input.";
 
@@ -2187,14 +2192,14 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
         protected void gRequests_RowDataBound( object sender, GridViewRowEventArgs e )
         {
-            if (e.Row.RowType != DataControlRowType.DataRow)
+            if ( e.Row.RowType != DataControlRowType.DataRow )
             {
                 return;
             }
 
             var viewModel = e.Row.DataItem as ConnectionRequestViewModel;
 
-            if (viewModel == null)
+            if ( viewModel == null )
             {
                 return;
             }
@@ -2202,7 +2207,7 @@ namespace RockWeb.Blocks.Connection
             // Status icons
             var lStatusIcons = e.Row.FindControl( "lStatusIcons" ) as Literal;
 
-            if (lStatusIcons != null)
+            if ( lStatusIcons != null )
             {
                 lStatusIcons.Text = GetStatusIconHtml( viewModel );
             }
@@ -2210,7 +2215,7 @@ namespace RockWeb.Blocks.Connection
             // Status
             var lStatus = e.Row.FindControl( "lStatus" ) as Literal;
 
-            if (lStatus != null)
+            if ( lStatus != null )
             {
                 lStatus.Text = string.Format(
                     @"<span class=""label label-default"" style=""background-color: {0}"">{1}</span>",
@@ -2221,7 +2226,7 @@ namespace RockWeb.Blocks.Connection
             // State
             var lState = e.Row.FindControl( "lState" ) as Literal;
 
-            if (lState != null)
+            if ( lState != null )
             {
                 lState.Text = viewModel.StateLabel;
             }
@@ -2256,9 +2261,9 @@ namespace RockWeb.Blocks.Connection
 
             var authorizedWorkflows = new List<ConnectionRequestWorkflow>();
 
-            foreach (var requestWorkfFlow in instantiatedWorkflows)
+            foreach ( var requestWorkfFlow in instantiatedWorkflows )
             {
-                if (requestWorkfFlow.Workflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ))
+                if ( requestWorkfFlow.Workflow.WorkflowType.IsAuthorized( Authorization.VIEW, CurrentPerson ) )
                 {
                     authorizedWorkflows.Add( requestWorkfFlow );
                 }
@@ -2281,7 +2286,7 @@ namespace RockWeb.Blocks.Connection
 
             gRequestModalViewModeWorkflows.DataBind();
 
-            if (!authorizedWorkflows.Any())
+            if ( !authorizedWorkflows.Any() )
             {
                 wpRequestModalViewModeWorkflow.Visible = false;
             }
@@ -2310,12 +2315,12 @@ namespace RockWeb.Blocks.Connection
                 .Where( w => w.Guid == guid )
                 .FirstOrDefault();
 
-            if (requestWorkflow == null || requestWorkflow.Workflow == null)
+            if ( requestWorkflow == null || requestWorkflow.Workflow == null )
             {
                 return;
             }
 
-            if (requestWorkflow.Workflow.HasActiveEntryForm( CurrentPerson ))
+            if ( requestWorkflow.Workflow.HasActiveEntryForm( CurrentPerson ) )
             {
                 RegisterWorkflowDetailPageScript( requestWorkflow.Workflow.WorkflowTypeId, requestWorkflow.Workflow.Guid );
             }
@@ -2343,7 +2348,7 @@ namespace RockWeb.Blocks.Connection
             // When the script is executed, it is also removed from the client load event to ensure that it is only run once.
             string script;
 
-            if (string.IsNullOrEmpty( message ))
+            if ( string.IsNullOrEmpty( message ) )
             {
                 // Open the workflow detail page.
                 script = $@"
@@ -2391,30 +2396,30 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="GridViewRowEventArgs"/> instance containing the event data.</param>
         protected void gRequestModalViewModeActivities_RowDataBound( object sender, GridViewRowEventArgs e )
         {
-            if (e.Row.RowType != DataControlRowType.DataRow)
+            if ( e.Row.RowType != DataControlRowType.DataRow )
             {
                 return;
             }
 
             var viewModel = e.Row.DataItem as ActivityViewModel;
 
-            if (viewModel == null)
+            if ( viewModel == null )
             {
                 return;
             }
 
-            if (viewModel.OpportunityId.HasValue && viewModel.OpportunityId.Value == ConnectionOpportunityId)
+            if ( viewModel.OpportunityId.HasValue && viewModel.OpportunityId.Value == ConnectionOpportunityId )
             {
                 e.Row.AddCssClass( "info" );
             }
 
-            if (!viewModel.CanEdit)
+            if ( !viewModel.CanEdit )
             {
                 var cellCount = e.Row.Cells.Count;
                 var lastCell = e.Row.Cells[cellCount - 1];
-                var lbDelete = (lastCell.Controls.Count > 0 ? lastCell.Controls[0] : null) as LinkButton;
+                var lbDelete = ( lastCell.Controls.Count > 0 ? lastCell.Controls[0] : null ) as LinkButton;
 
-                if (lbDelete != null)
+                if ( lbDelete != null )
                 {
                     lbDelete.Enabled = false;
                 }
@@ -2430,7 +2435,7 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = e.Row.DataItem as ActivityViewModel;
 
-            if (viewModel == null || !viewModel.CanEdit)
+            if ( viewModel == null || !viewModel.CanEdit )
             {
                 return;
             }
@@ -2448,7 +2453,7 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if (viewModel == null || viewModel.ConnectionState == ConnectionState.Inactive || viewModel.ConnectionState == ConnectionState.Connected)
+            if ( viewModel == null || viewModel.ConnectionState == ConnectionState.Inactive || viewModel.ConnectionState == ConnectionState.Connected )
             {
                 return false;
             }
@@ -2457,25 +2462,86 @@ namespace RockWeb.Blocks.Connection
             return connectionOpportunities != null && connectionOpportunities.Count > 1 && CanUserEditConnectionRequest();
         }
 
+        private bool CanUserEditConnectionRequest()
+        {
+            var connectionOpportunity = GetConnectionOpportunity();
+            var connectionRequest = GetConnectionRequest();
+            var connectionType = GetConnectionType();
+
+            var userCanEditConnectionRequest = false;
+
+            if ( connectionType != null && connectionType.EnableRequestSecurity && connectionRequest != null )
+            {
+                userCanEditConnectionRequest = connectionRequest.IsAuthorized( Authorization.EDIT, CurrentPerson );
+            }
+            else if ( connectionOpportunity != null )
+            {
+                userCanEditConnectionRequest = connectionOpportunity.IsAuthorized( Authorization.EDIT, CurrentPerson );
+            }
+
+            // Grants edit access to those in the opportunity's connector groups
+            if ( !userCanEditConnectionRequest && CurrentPersonId.HasValue )
+            {
+                var qryConnectionOpportunityConnectorGroups = new ConnectionOpportunityConnectorGroupService( new RockContext() )
+                    .Queryable()
+                    .AsNoTracking()
+                    .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id );
+                var campuses = CampusCache.All().Where( c => c.IsActive ?? true ).ToList();
+
+                // Grant edit access to any of those in a non campus-specific connector group
+                userCanEditConnectionRequest = qryConnectionOpportunityConnectorGroups
+                    .Any( g =>
+                        ( campuses.Count == 1 || !g.CampusId.HasValue ) &&
+                        g.ConnectorGroup != null &&
+                        g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId && m.GroupMemberStatus == GroupMemberStatus.Active ) );
+
+                if ( !userCanEditConnectionRequest )
+                {
+                    // If this is a new request, grant edit access to any connector group. Otherwise, match the request's campus to the corresponding campus-specific connector group
+                    var groupCampuses = qryConnectionOpportunityConnectorGroups
+                        .Where( g =>
+                            g.ConnectorGroup != null &&
+                            g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId ) );
+
+                    if ( connectionRequest != null )
+                    {
+                        groupCampuses = groupCampuses.Where( g => ( connectionRequest.Id == 0 || ( connectionRequest.CampusId.HasValue && g.CampusId == connectionRequest.CampusId.Value ) ) );
+                    }
+
+                    foreach ( var groupCampus in groupCampuses )
+                    {
+                        userCanEditConnectionRequest = true;
+                        break;
+                    }
+                }
+            }
+
+            return userCanEditConnectionRequest;
+        }
+
         /// <summary>
-        /// SECC: Performs check to see if the user can connect the request based on if
-        /// Safety and Security needs to approve the connection request.
+        /// SECC: Returns true if the current user may connect the request, based on the opportunity's
+        /// SecurityToConnect flag and the configured Safety &amp; Security role.
+        /// Fails closed: returns false if the opportunity or request cannot be resolved.
         /// </summary>
-        /// <returns></returns>
         private bool CanUserConnect()
         {
             var connectionOpportunity = GetConnectionOpportunity();
-            connectionOpportunity.LoadAttributes();
-            var requiresSecurityToConnect = connectionOpportunity.GetAttributeValue( "SecurityToConnect" ).AsBooleanOrNull();
 
-            //does not require security check
-            if (!requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value)
+            if ( connectionOpportunity == null )
+            {
+                return false;
+            }
+
+            connectionOpportunity.LoadAttributes();
+            var requiresSecurityToConnect = GetRequiresSecurityToConnect( connectionOpportunity );
+
+            if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
             {
                 return true;
             }
 
-            // ROCK-8640: enforce S&S role gate before the empty-status short-circuit
-            if (!UserIsAuthorizedToConnect())
+            if ( !UserIsAuthorizedToConnect() )
             {
                 return false;
             }
@@ -2485,21 +2551,27 @@ namespace RockWeb.Blocks.Connection
                 .Where( v => v.HasValue )
                 .ToList();
 
-            // if no connectable statuses defined, skip
-            if (connectableStatuses.Count() == 0)
+            if ( connectableStatuses.Count == 0 )
             {
                 return true;
             }
 
             var connectionRequest = GetConnectionRequest();
 
-            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId ) || connectionRequest.ConnectionState == ConnectionState.Connected;
+            // Add mode: no request yet — don't block modal rendering.
+            if ( connectionRequest == null )
+            {
+                return true;
+            }
+
+            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
+                || connectionRequest.ConnectionState == ConnectionState.Connected;
         }
 
         /// <summary>
-        /// True if the current person may bypass or satisfy the S&S connect gate:
-        /// Rock Administrators always may; otherwise the person must be in the configured S&S role.
-        /// If no S&S role is configured, only Rock Administrators pass.
+        /// SECC: Returns true if the current person satisfies the S&amp;S connect gate:
+        /// Rock Administrators always pass; otherwise the person must be in the configured S&amp;S role.
+        /// If no S&amp;S role is configured, only Rock Administrators pass.
         /// </summary>
         private bool UserIsAuthorizedToConnect()
         {
@@ -2524,61 +2596,29 @@ namespace RockWeb.Blocks.Connection
             return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
         }
 
-        private bool CanUserEditConnectionRequest()
+        // ROCK-8640: attribute keys for the SecurityToConnect flag across all opportunity types.
+        private static readonly string[] SecurityToConnectAttributeKeys =
         {
-            var connectionOpportunity = GetConnectionOpportunity();
-            var connectionRequest = GetConnectionRequest();
-            var connectionType = GetConnectionType();
+            "SecurityToConnect",
+            "RequireSafetySecuritytoConnect",      // RISE
+            "RequireSafetyandSecuritytoConnect"    // Lightning Lane
+        };
 
-            var userCanEditConnectionRequest = false;
-
-            if (connectionType != null && connectionType.EnableRequestSecurity && connectionRequest != null)
+        /// <summary>
+        /// SECC: Returns the first non-null SecurityToConnect value found across all known attribute keys.
+        /// </summary>
+        private static bool? GetRequiresSecurityToConnect( ConnectionOpportunity opportunity )
+        {
+            foreach ( var key in SecurityToConnectAttributeKeys )
             {
-                userCanEditConnectionRequest = connectionRequest.IsAuthorized( Authorization.EDIT, CurrentPerson );
-            }
-            else if (connectionOpportunity != null)
-            {
-                userCanEditConnectionRequest = connectionOpportunity.IsAuthorized( Authorization.EDIT, CurrentPerson );
-            }
-
-            // Grants edit access to those in the opportunity's connector groups
-            if (!userCanEditConnectionRequest && CurrentPersonId.HasValue)
-            {
-                var qryConnectionOpportunityConnectorGroups = new ConnectionOpportunityConnectorGroupService( new RockContext() )
-                    .Queryable()
-                    .AsNoTracking()
-                    .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id );
-                var campuses = CampusCache.All().Where( c => c.IsActive ?? true ).ToList();
-
-                // Grant edit access to any of those in a non campus-specific connector group
-                userCanEditConnectionRequest = qryConnectionOpportunityConnectorGroups
-                    .Any( g =>
-                        (campuses.Count == 1 || !g.CampusId.HasValue) &&
-                        g.ConnectorGroup != null &&
-                        g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId && m.GroupMemberStatus == GroupMemberStatus.Active ) );
-
-                if (!userCanEditConnectionRequest)
+                var value = opportunity.GetAttributeValue( key ).AsBooleanOrNull();
+                if ( value.HasValue )
                 {
-                    // If this is a new request, grant edit access to any connector group. Otherwise, match the request's campus to the corresponding campus-specific connector group
-                    var groupCampuses = qryConnectionOpportunityConnectorGroups
-                        .Where( g =>
-                            g.ConnectorGroup != null &&
-                            g.ConnectorGroup.Members.Any( m => m.PersonId == CurrentPersonId ) );
-
-                    if (connectionRequest != null)
-                    {
-                        groupCampuses = groupCampuses.Where( g => (connectionRequest.Id == 0 || (connectionRequest.CampusId.HasValue && g.CampusId == connectionRequest.CampusId.Value)) );
-                    }
-
-                    foreach (var groupCampus in groupCampuses)
-                    {
-                        userCanEditConnectionRequest = true;
-                        break;
-                    }
+                    return value;
                 }
             }
 
-            return userCanEditConnectionRequest;
+            return null;
         }
 
         /// <summary>
@@ -2597,7 +2637,7 @@ namespace RockWeb.Blocks.Connection
 
             var activityViewModelQuery = GetActivityViewModelQuery();
 
-            if (ViewAllActivities)
+            if ( ViewAllActivities )
             {
                 gRequestModalViewModeActivities.DataSource = activityViewModelQuery.ToList();
                 lbRequestModalViewModeShowAllActivities.Visible = false;
@@ -2633,7 +2673,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbRequestModalViewModeAddActivity_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -2650,7 +2690,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeAddActivityModeSave_Click( object sender, EventArgs e )
         {
-            if (!ConnectionRequestId.HasValue || !CanUserEditConnectionRequest())
+            if ( !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -2660,7 +2700,7 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestActivityService( rockContext );
             var activity = isAddMode ? new ConnectionRequestActivity() : service.Get( CurrentActivityId.Value );
 
-            if (activity == null)
+            if ( activity == null )
             {
                 return;
             }
@@ -2671,7 +2711,7 @@ namespace RockWeb.Blocks.Connection
             activity.ConnectionActivityTypeId = ddlRequestModalViewModeAddActivityModeType.SelectedValue.AsInteger();
             activity.ConnectionOpportunityId = ConnectionOpportunityId;
 
-            if (isAddMode)
+            if ( isAddMode )
             {
                 service.Add( activity );
             }
@@ -2680,7 +2720,7 @@ namespace RockWeb.Blocks.Connection
             RequestModalViewModeSubMode = RequestModalViewModeSubMode_View;
             ShowRequestModal();
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -2697,7 +2737,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="RowEventArgs"/> instance containing the event data.</param>
         protected void gRequestModalViewModeActivities_Delete( object sender, RowEventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -2710,7 +2750,7 @@ namespace RockWeb.Blocks.Connection
             connectionRequestActivityService.DeleteRange( query );
             rockContext.SaveChanges();
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -2736,7 +2776,7 @@ namespace RockWeb.Blocks.Connection
         {
             var opportunityId = e.CommandArgument.ToString().AsIntegerOrNull();
 
-            if (opportunityId.HasValue)
+            if ( opportunityId.HasValue )
             {
                 ddlRequestModalViewModeTransferModeOpportunity.SetValue( opportunityId.ToString() );
             }
@@ -2756,7 +2796,7 @@ namespace RockWeb.Blocks.Connection
             cblSearchModalCampus.DataSource = CampusCache.All().Where( c => c.IsActive != false );
             cblSearchModalCampus.DataBind();
 
-            if (request.CampusId.HasValue)
+            if ( request.CampusId.HasValue )
             {
                 cblSearchModalCampus.SetValues( new List<string> { request.CampusId.Value.ToString() } );
             }
@@ -2777,15 +2817,15 @@ namespace RockWeb.Blocks.Connection
             phSearchModalAttributeFilters.Controls.Clear();
             var searchAttributes = GetSearchAttributes();
 
-            foreach (var attribute in searchAttributes)
+            foreach ( var attribute in searchAttributes )
             {
                 var control = attribute.FieldType.Field.FilterControl( attribute.QualifierValues, "filter_" + attribute.Id.ToString(), false, Rock.Reporting.FilterMode.SimpleFilter );
 
-                if (control != null)
+                if ( control != null )
                 {
-                    if (control is IRockControl)
+                    if ( control is IRockControl )
                     {
-                        var rockControl = (IRockControl) control;
+                        var rockControl = ( IRockControl ) control;
                         rockControl.Label = attribute.Name;
                         rockControl.Help = attribute.Description;
                         phSearchModalAttributeFilters.Controls.Add( control );
@@ -2812,7 +2852,7 @@ namespace RockWeb.Blocks.Connection
             var rockContext = new RockContext();
             var connectionOpportunityID = ddlRequestModalViewModeTransferModeOpportunity.SelectedValue.AsIntegerOrNull();
             var connectionOpportunity = new ConnectionOpportunityService( rockContext ).Get( connectionOpportunityID.Value );
-            if (connectionOpportunity != null)
+            if ( connectionOpportunity != null )
             {
                 rbRequestModalViewModeTransferModeDefaultConnector.Text = "Default Connector for " + connectionOpportunity.Name;
             }
@@ -2827,7 +2867,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransferModeSearch_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -2856,19 +2896,19 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransferModeSave_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
 
-            using (var rockContext = new RockContext())
+            using ( var rockContext = new RockContext() )
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionActivityTypeService = new ConnectionActivityTypeService( rockContext );
                 var connectionRequestActivityService = new ConnectionRequestActivityService( rockContext );
 
                 var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
-                if (connectionRequest != null)
+                if ( connectionRequest != null )
                 {
                     int? newOpportunityId = ddlRequestModalViewModeTransferModeOpportunity.SelectedValueAsId();
                     int? sourceConnectorPersonAliasId = connectionRequest.ConnectorPersonAliasId;
@@ -2882,18 +2922,18 @@ namespace RockWeb.Blocks.Connection
                         .Select( t => t.Id )
                         .FirstOrDefault();
 
-                    if (newOpportunityId.HasValue && transferredActivityId > 0)
+                    if ( newOpportunityId.HasValue && transferredActivityId > 0 )
                     {
                         var newOpportunity = new ConnectionOpportunityService( rockContext ).Get( newOpportunityId.Value );
 
                         connectionRequest.ConnectionOpportunityId = newOpportunityId.Value;
-                        if (newOpportunity.ShowStatusOnTransfer && ddlRequestModalViewModeTransferModeStatus.Visible)
+                        if ( newOpportunity.ShowStatusOnTransfer && ddlRequestModalViewModeTransferModeStatus.Visible )
                         {
                             var newStatusId = ddlRequestModalViewModeTransferModeStatus.SelectedValueAsId();
                             connectionRequest.ConnectionStatusId = newStatusId.Value;
                         }
 
-                        if (newOpportunity.ShowCampusOnTransfer && cpTransferCampus.Visible)
+                        if ( newOpportunity.ShowCampusOnTransfer && cpTransferCampus.Visible )
                         {
                             connectionRequest.CampusId = cpTransferCampus.SelectedCampusId;
                         }
@@ -2903,13 +2943,13 @@ namespace RockWeb.Blocks.Connection
                         connectionRequest.AssignedGroupMemberStatus = null;
 
                         // assign the connector based on the selection
-                        if (rbTRequestModalViewModeTransferModeCurrentConnector.Checked)
+                        if ( rbTRequestModalViewModeTransferModeCurrentConnector.Checked )
                         {
                             // just leave the connector that they had
                         }
-                        else if (rbRequestModalViewModeTransferModeDefaultConnector.Checked)
+                        else if ( rbRequestModalViewModeTransferModeDefaultConnector.Checked )
                         {
-                            if (newOpportunity != null)
+                            if ( newOpportunity != null )
                             {
                                 connectionRequest.ConnectorPersonAliasId = newOpportunity.GetDefaultConnectorPersonAliasId( connectionRequest.CampusId );
                             }
@@ -2918,18 +2958,18 @@ namespace RockWeb.Blocks.Connection
                                 connectionRequest.ConnectorPersonAliasId = null;
                             }
                         }
-                        else if (rbRequestModalViewModeTransferModeNoConnector.Checked)
+                        else if ( rbRequestModalViewModeTransferModeNoConnector.Checked )
                         {
                             connectionRequest.ConnectorPersonAliasId = null;
                         }
-                        else if (rbRequestModalViewModeTransferModeSelectConnector.Checked)
+                        else if ( rbRequestModalViewModeTransferModeSelectConnector.Checked )
                         {
                             int? connectorPersonId = ddlRequestModalViewModeTransferModeOpportunityConnector.SelectedValue.AsIntegerOrNull();
                             int? connectorPersonAliasId = null;
-                            if (connectorPersonId.HasValue)
+                            if ( connectorPersonId.HasValue )
                             {
                                 var connectorPerson = new PersonService( rockContext ).Get( connectorPersonId.Value );
-                                if (connectorPerson != null)
+                                if ( connectorPerson != null )
                                 {
                                     connectorPersonAliasId = connectorPerson.PrimaryAliasId;
                                 }
@@ -2939,7 +2979,7 @@ namespace RockWeb.Blocks.Connection
                         }
 
                         // if the Opportunity and Connector haven't changed then don't transfer.
-                        if (connectionRequest.ConnectionOpportunityId == sourceOpportunityId && connectionRequest.ConnectorPersonAliasId == sourceConnectorPersonAliasId)
+                        if ( connectionRequest.ConnectionOpportunityId == sourceOpportunityId && connectionRequest.ConnectorPersonAliasId == sourceConnectorPersonAliasId )
                         {
                             nbTranferFailed.Visible = true;
                             return;
@@ -2957,7 +2997,7 @@ namespace RockWeb.Blocks.Connection
 
                         rockContext.SaveChanges();
 
-                        if (ConnectionOpportunityId != connectionRequest.ConnectionOpportunityId)
+                        if ( ConnectionOpportunityId != connectionRequest.ConnectionOpportunityId )
                         {
                             // Connection opportunity changed
                             ConnectionOpportunityId = connectionRequest.ConnectionOpportunityId;
@@ -2966,7 +3006,7 @@ namespace RockWeb.Blocks.Connection
                             LoadSettings();
                             BindUI();
                         }
-                        else if (IsCardViewMode)
+                        else if ( IsCardViewMode )
                         {
                             RefreshRequestCard();
                         }
@@ -2981,7 +3021,7 @@ namespace RockWeb.Blocks.Connection
                 }
             }
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -3020,27 +3060,27 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void lbSearchModalSearch_Click( object sender, EventArgs e )
         {
-            using (var rockContext = new RockContext())
+            using ( var rockContext = new RockContext() )
             {
                 var connectionRequestService = new ConnectionRequestService( rockContext );
                 var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
-                if (connectionRequest != null &&
+                if ( connectionRequest != null &&
                     connectionRequest.ConnectionOpportunity != null &&
-                    connectionRequest.ConnectionOpportunity.ConnectionType != null)
+                    connectionRequest.ConnectionOpportunity.ConnectionType != null )
                 {
                     var connectionOpportunityService = new ConnectionOpportunityService( rockContext );
                     var connectionTypeId = connectionRequest.ConnectionOpportunity.ConnectionTypeId;
 
                     var qrySearch = connectionOpportunityService.Queryable().Where( a => a.ConnectionTypeId == connectionTypeId && a.IsActive == true );
 
-                    if (!string.IsNullOrWhiteSpace( tbSearchModalName.Text ))
+                    if ( !string.IsNullOrWhiteSpace( tbSearchModalName.Text ) )
                     {
                         var searchTerms = tbSearchModalName.Text.ToLower().SplitDelimitedValues( true );
                         qrySearch = qrySearch.Where( o => searchTerms.Any( t => t.Contains( o.Name.ToLower() ) || o.Name.ToLower().Contains( t ) ) );
                     }
 
                     var searchCampuses = cblSearchModalCampus.SelectedValuesAsInt;
-                    if (searchCampuses.Count > 0)
+                    if ( searchCampuses.Count > 0 )
                     {
                         qrySearch = qrySearch.Where( o => o.ConnectionOpportunityCampuses.Any( c => searchCampuses.Contains( c.CampusId ) ) );
                     }
@@ -3048,9 +3088,9 @@ namespace RockWeb.Blocks.Connection
                     // Filter query by any configured attribute filters
                     var searchAttributes = GetSearchAttributes();
 
-                    if (searchAttributes != null && searchAttributes.Any())
+                    if ( searchAttributes != null && searchAttributes.Any() )
                     {
-                        foreach (var attribute in searchAttributes)
+                        foreach ( var attribute in searchAttributes )
                         {
                             var filterControl = phSearchModalAttributeFilters.FindControl( "filter_" + attribute.Id.ToString() );
                             qrySearch = attribute.FieldType.Field.ApplyAttributeQueryFilter( qrySearch, filterControl, attribute, connectionRequestService, Rock.Reporting.FilterMode.SimpleFilter );
@@ -3086,7 +3126,7 @@ namespace RockWeb.Blocks.Connection
                 "Unassigned" :
                 viewModel.ConnectorPersonFullname;
 
-            if (viewModel.ConnectorPersonAliasId.HasValue)
+            if ( viewModel.ConnectorPersonAliasId.HasValue )
             {
                 lRequestModalViewModeConnectorProfilePhoto.Text = string.Format(
                     @"<div class=""board-card-photo mb-1"" style=""background-image: url( '{0}' );"" title=""{1} Profile Photo""></div>",
@@ -3135,7 +3175,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeEdit_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -3152,7 +3192,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeTransfer_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -3170,7 +3210,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestViewModeViewHistory_Click( object sender, EventArgs e )
         {
-            if (!ConnectionRequestId.HasValue)
+            if ( !ConnectionRequestId.HasValue )
             {
                 return;
             }
@@ -3179,7 +3219,7 @@ namespace RockWeb.Blocks.Connection
             var connectionRequestService = new ConnectionRequestService( rockContext );
             var connectionRequest = connectionRequestService.Get( ConnectionRequestId.Value );
 
-            if (connectionRequest != null)
+            if ( connectionRequest != null )
             {
                 NavigateToLinkedPage( AttributeKey.ConnectionRequestHistoryPage, new Dictionary<string, string> { { PageParameterKey.ConnectionRequestGuid, connectionRequest.Guid.ToString() } } );
             }
@@ -3192,7 +3232,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeConnect_Click( object sender, EventArgs e )
         {
-            if (!CanUserEditConnectionRequest())
+            if ( !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -3200,7 +3240,7 @@ namespace RockWeb.Blocks.Connection
             MarkRequestConnected();
             ShowRequestModal();
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -3219,7 +3259,7 @@ namespace RockWeb.Blocks.Connection
         {
             var newConnectorPersonAliasId = e.CommandArgument.ToStringSafe().AsIntegerOrNull();
 
-            if (!newConnectorPersonAliasId.HasValue || !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest())
+            if ( !newConnectorPersonAliasId.HasValue || !ConnectionRequestId.HasValue || !CanUserEditConnectionRequest() )
             {
                 return;
             }
@@ -3228,12 +3268,12 @@ namespace RockWeb.Blocks.Connection
             var service = new ConnectionRequestService( rockContext );
             var request = service.Get( ConnectionRequestId.Value );
 
-            if (request == null)
+            if ( request == null )
             {
                 return;
             }
 
-            if (newConnectorPersonAliasId.Value == 0)
+            if ( newConnectorPersonAliasId.Value == 0 )
             {
                 request.ConnectorPersonAliasId = null;
             }
@@ -3244,7 +3284,7 @@ namespace RockWeb.Blocks.Connection
 
             rockContext.SaveChanges();
 
-            if (request.ConnectorPersonAliasId.HasValue)
+            if ( request.ConnectorPersonAliasId.HasValue )
             {
                 AddAssignedActivity();
                 BindRequestModalViewModeActivitiesGrid();
@@ -3254,7 +3294,7 @@ namespace RockWeb.Blocks.Connection
             BindModalViewModeBadges();
             BindModalViewModeConnectorOptions();
 
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 RefreshRequestCard();
             }
@@ -3280,7 +3320,7 @@ namespace RockWeb.Blocks.Connection
             lRequestModalViewModeRequirementsLabels.Text = string.Empty;
 
             // If the connect button will not be shown, then there is no need to show the requirements
-            if (!request.CanConnect)
+            if ( !request.CanConnect )
             {
                 cblRequestModalViewModeManualRequirements.Visible = false;
                 rcwRequestModalViewModeRequirements.Visible = false;
@@ -3293,13 +3333,13 @@ namespace RockWeb.Blocks.Connection
             cblRequestModalViewModeManualRequirements.Visible = true;
             var passedAllRequirements = true;
 
-            foreach (var requirementResult in requirementsResults)
+            foreach ( var requirementResult in requirementsResults )
             {
-                if (requirementResult.GroupRequirement.GroupRequirementType.RequirementCheckType == RequirementCheckType.Manual)
+                if ( requirementResult.GroupRequirement.GroupRequirementType.RequirementCheckType == RequirementCheckType.Manual )
                 {
                     var checkboxItem = new ListItem( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel, requirementResult.GroupRequirement.Id.ToString() );
 
-                    if (string.IsNullOrEmpty( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel ))
+                    if ( string.IsNullOrEmpty( requirementResult.GroupRequirement.GroupRequirementType.CheckboxLabel ) )
                     {
                         checkboxItem.Text = requirementResult.GroupRequirement.GroupRequirementType.Name;
                     }
@@ -3313,19 +3353,19 @@ namespace RockWeb.Blocks.Connection
                     string labelType;
                     string labelTooltip;
 
-                    if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.Meets)
+                    if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.Meets )
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.PositiveLabel;
                         labelType = "success";
                     }
-                    else if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning)
+                    else if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning )
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.WarningLabel;
                         labelType = "warning";
                     }
                     else
                     {
-                        if (requirementResult.GroupRequirement.MustMeetRequirementToAddMember)
+                        if ( requirementResult.GroupRequirement.MustMeetRequirementToAddMember )
                         {
                             passedAllRequirements = false;
                             labelText = requirementResult.GroupRequirement.GroupRequirementType.NegativeLabel;
@@ -3338,12 +3378,12 @@ namespace RockWeb.Blocks.Connection
                         }
                     }
 
-                    if (string.IsNullOrEmpty( labelText ))
+                    if ( string.IsNullOrEmpty( labelText ) )
                     {
                         labelText = requirementResult.GroupRequirement.GroupRequirementType.Name;
                     }
 
-                    if (requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning)
+                    if ( requirementResult.MeetsGroupRequirement == MeetsGroupRequirement.MeetsWithWarning )
                     {
                         labelTooltip = requirementResult.RequirementWarningDateTime.HasValue
                             ? "Last Checked: " + requirementResult.RequirementWarningDateTime.Value.ToString( "g" )
@@ -3367,7 +3407,7 @@ namespace RockWeb.Blocks.Connection
 
             var requirementsWithErrors = requirementsResults.Where( a => a.MeetsGroupRequirement == MeetsGroupRequirement.Error ).ToList();
 
-            if (requirementsWithErrors.Any())
+            if ( requirementsWithErrors.Any() )
             {
                 var text = string.Format(
                     "An error occurred in one or more of the requirement calculations: <br /> {0}",
@@ -3389,7 +3429,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="System.Web.UI.WebControls.RepeaterItemEventArgs"/> instance containing the event data.</param>
         protected void rptConnnectionTypes_ItemDataBound( object sender, RepeaterItemEventArgs e )
         {
-            if (e.Item.ItemType != ListItemType.Item && e.Item.ItemType != ListItemType.AlternatingItem)
+            if ( e.Item.ItemType != ListItemType.Item && e.Item.ItemType != ListItemType.AlternatingItem )
             {
                 return;
             }
@@ -3516,7 +3556,7 @@ namespace RockWeb.Blocks.Connection
             SaveSettingByConnectionType( UserPreferenceKey.SortBy, value ?? string.Empty );
             ConnectionRequestViewModelSortProperty sortProperty;
 
-            if (!value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ))
+            if ( !value.IsNullOrWhiteSpace() && Enum.TryParse( value, out sortProperty ) )
             {
                 CurrentSortProperty = sortProperty;
             }
@@ -3617,7 +3657,7 @@ namespace RockWeb.Blocks.Connection
 
             var personId = LoadSettingByConnectionType( FilterKey.Requester ).AsIntegerOrNull();
 
-            if (personId.HasValue)
+            if ( personId.HasValue )
             {
                 var rockContext = new RockContext();
                 var personService = new PersonService( rockContext );
@@ -3638,7 +3678,7 @@ namespace RockWeb.Blocks.Connection
                 sdrpLastActivityDateRangeFilter.SelectedDateRange.End.HasValue ||
                 rcbPastDueOnly.Checked;
 
-            if (hasFilter)
+            if ( hasFilter )
             {
                 aFilterDrawerToggle.AddCssClass( "bg-warning" );
             }
@@ -3653,7 +3693,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindViewModeToggle()
         {
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 lbToggleViewMode.Text = @"<i class=""fa fa-list""></i> List";
             }
@@ -3671,7 +3711,7 @@ namespace RockWeb.Blocks.Connection
             var campuseViewModels = GetCampusViewModels();
 
             // If there is only 1 campus, then we don't show campus controls throughout Rock
-            if (campuseViewModels.Count <= 1)
+            if ( campuseViewModels.Count <= 1 )
             {
                 CampusId = null;
                 divCampusBtnGroup.Visible = false;
@@ -3698,11 +3738,11 @@ namespace RockWeb.Blocks.Connection
             var connectorViewModels = GetConnectors( false, CampusId, null )
                 .Where( cvm => cvm.PersonAliasId != CurrentPersonAliasId );
 
-            if (!ConnectorPersonAliasId.HasValue)
+            if ( !ConnectorPersonAliasId.HasValue )
             {
                 lConnectorText.Text = "All Connectors";
             }
-            else if (ConnectorPersonAliasId == CurrentPersonAliasId)
+            else if ( ConnectorPersonAliasId == CurrentPersonAliasId )
             {
                 lConnectorText.Text = "My Connections";
             }
@@ -3710,7 +3750,7 @@ namespace RockWeb.Blocks.Connection
             {
                 var connector = connectorViewModels.FirstOrDefault( c => c.PersonAliasId == ConnectorPersonAliasId );
 
-                if (connector != null)
+                if ( connector != null )
                 {
                     lConnectorText.Text = string.Format( "Connector: {0}", connector.Fullname );
                 }
@@ -3730,7 +3770,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindSortOptions()
         {
-            switch (CurrentSortProperty)
+            switch ( CurrentSortProperty )
             {
                 case ConnectionRequestViewModelSortProperty.Requestor:
                 case ConnectionRequestViewModelSortProperty.RequestorDesc:
@@ -3774,7 +3814,7 @@ namespace RockWeb.Blocks.Connection
             var viewModels = GetConnectionTypeViewModels();
             var personAliasId = CurrentPersonAliasId;
 
-            if (!personAliasId.HasValue)
+            if ( !personAliasId.HasValue )
             {
                 return;
             }
@@ -3797,7 +3837,7 @@ namespace RockWeb.Blocks.Connection
                 .Where( co => favoriteIds.Contains( co.Id ) )
                 .ToList();
 
-            if (favoriteConnectionOpportunities.Any())
+            if ( favoriteConnectionOpportunities.Any() )
             {
                 rptFavoriteConnectionOpportunities.DataSource = favoriteConnectionOpportunities;
                 rptFavoriteConnectionOpportunities.DataBind();
@@ -3854,7 +3894,7 @@ namespace RockWeb.Blocks.Connection
             ddlCampaignConnectionItemsMultiple.Items.Clear();
 
             var campaignConnectionItemsPendingCount = new Dictionary<CampaignItem, int>();
-            foreach (var campaignConnectionItem in campaignConnectionItems)
+            foreach ( var campaignConnectionItem in campaignConnectionItems )
             {
                 int pendingCount = CampaignConnectionHelper.GetPendingConnectionCount( campaignConnectionItem, CurrentPerson );
                 campaignConnectionItemsPendingCount.AddOrIgnore( campaignConnectionItem, pendingCount );
@@ -3868,7 +3908,7 @@ namespace RockWeb.Blocks.Connection
             nbNumberOfRequests.Visible = true;
             mdAddCampaignRequests.SaveButtonText = "Assign";
 
-            if (campaignConnectionItems.Count() == 0)
+            if ( campaignConnectionItems.Count() == 0 )
             {
                 nbAddConnectionRequestsMessage.Text = "There are no campaigns available for you to request connections for.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = NotificationBoxType.Warning;
@@ -3878,7 +3918,7 @@ namespace RockWeb.Blocks.Connection
                 nbNumberOfRequests.Visible = false;
                 mdAddCampaignRequests.SaveButtonText = string.Empty;
             }
-            else if (campaignConnectionItems.Count() == 1)
+            else if ( campaignConnectionItems.Count() == 1 )
             {
                 var campaignConnectionItem = campaignConnectionItems[0];
                 lCampaignConnectionItemSingle.Visible = true;
@@ -3892,7 +3932,7 @@ namespace RockWeb.Blocks.Connection
                 ddlCampaignConnectionItemsMultiple.Visible = true;
             }
 
-            if (campaignConnectionItems.Count > 0)
+            if ( campaignConnectionItems.Count > 0 )
             {
                 var firstCampaignConnectionItem = campaignConnectionItems.First();
                 SetDefaultNumberOfRequests( firstCampaignConnectionItem.Guid, campaignConnectionItemsPendingCount.GetValueOrNull( firstCampaignConnectionItem ) ?? 0 );
@@ -3907,7 +3947,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="selectedCampaignConnectionItemGuid">The selected campaign connection item unique identifier.</param>
         private void SetDefaultNumberOfRequests( Guid? selectedCampaignConnectionItemGuid, int pendingCount )
         {
-            if (!selectedCampaignConnectionItemGuid.HasValue)
+            if ( !selectedCampaignConnectionItemGuid.HasValue )
             {
                 // shouldn't happen
                 return;
@@ -3927,29 +3967,29 @@ namespace RockWeb.Blocks.Connection
             // Check to see if the group member has any CampaignDailyLimit values defined.
             var currentPersonConnectorGroupMember = opportunityConnecterGroupQuery
                 .Select( s => s.ConnectorGroup ).SelectMany( g => g.Members )
-                .WhereAttributeValue( rockContext, av => (av.Attribute.Key == "CampaignDailyLimit") && av.ValueAsNumeric > 0 )
+                .WhereAttributeValue( rockContext, av => ( av.Attribute.Key == "CampaignDailyLimit" ) && av.ValueAsNumeric > 0 )
                 .FirstOrDefault( m => m.PersonId == this.CurrentPersonId.Value );
 
-            if (currentPersonConnectorGroupMember != null)
+            if ( currentPersonConnectorGroupMember != null )
             {
                 currentPersonConnectorGroupMember.LoadAttributes();
                 defaultDailyLimitAssigned = currentPersonConnectorGroupMember.GetAttributeValue( "CampaignDailyLimit" ).AsIntegerOrNull();
             }
 
-            if (defaultDailyLimitAssigned == null && selectedCampaignConnectionItem.CreateConnectionRequestOption == CreateConnectionRequestOptions.AsNeeded)
+            if ( defaultDailyLimitAssigned == null && selectedCampaignConnectionItem.CreateConnectionRequestOption == CreateConnectionRequestOptions.AsNeeded )
             {
                 defaultDailyLimitAssigned = selectedCampaignConnectionItem.DailyLimitAssigned;
             }
 
             var entitySetItemService = new EntitySetItemService( rockContext );
 
-            if (pendingCount == 0)
+            if ( pendingCount == 0 )
             {
                 nbAddConnectionRequestsMessage.Text = "There are no pending requests remaining.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
                 nbAddConnectionRequestsMessage.Visible = true;
             }
-            else if (pendingCount < defaultDailyLimitAssigned)
+            else if ( pendingCount < defaultDailyLimitAssigned )
             {
                 nbAddConnectionRequestsMessage.Text = string.Format( "There are only {0} pending requests remaining.", pendingCount );
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
@@ -3973,7 +4013,7 @@ namespace RockWeb.Blocks.Connection
         {
             // note if there is only one CampaignConnectionItem, ddlCampaignConnectionItemsMultiple will not be visible, but it is still the selected one, because there is only one
             var selectedCampaignConnectionItemGuid = ddlCampaignConnectionItemsMultiple.SelectedValue.AsGuidOrNull();
-            if (!selectedCampaignConnectionItemGuid.HasValue)
+            if ( !selectedCampaignConnectionItemGuid.HasValue )
             {
                 // shouldn't happen
                 return;
@@ -3982,7 +4022,7 @@ namespace RockWeb.Blocks.Connection
             var campaignConnectionItems = Rock.Web.SystemSettings.GetValue( CampaignConnectionKey.CAMPAIGN_CONNECTION_CONFIGURATION ).FromJsonOrNull<List<CampaignItem>>() ?? new List<CampaignItem>();
             var selectedCampaignConnectionItem = campaignConnectionItems.Where( a => a.Guid == selectedCampaignConnectionItemGuid.Value ).FirstOrDefault();
 
-            if (selectedCampaignConnectionItem == null)
+            if ( selectedCampaignConnectionItem == null )
             {
                 // shouldn't happen
                 return;
@@ -3992,7 +4032,7 @@ namespace RockWeb.Blocks.Connection
             numberOfRequests = nbNumberOfRequests.Text.AsInteger();
             CampaignConnectionHelper.AddConnectionRequestsForPerson( selectedCampaignConnectionItem, this.CurrentPerson, numberOfRequests, out numberOfRequestsRemaining );
 
-            if (numberOfRequestsRemaining == numberOfRequests)
+            if ( numberOfRequestsRemaining == numberOfRequests )
             {
                 nbAddConnectionRequestsMessage.Text = "Additional Requests are not available as this time.";
                 nbAddConnectionRequestsMessage.NotificationBoxType = Rock.Web.UI.Controls.NotificationBoxType.Info;
@@ -4011,7 +4051,7 @@ namespace RockWeb.Blocks.Connection
         protected void ddlCampaignConnectionItem_SelectedIndexChanged( object sender, EventArgs e )
         {
             var selectedCampaignConnectionItemGuid = ddlCampaignConnectionItemsMultiple.SelectedValue.AsGuidOrNull();
-            if (!selectedCampaignConnectionItemGuid.HasValue)
+            if ( !selectedCampaignConnectionItemGuid.HasValue )
             {
                 // shouldn't happen
                 return;
@@ -4050,12 +4090,12 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindUI()
         {
-            if (!ConnectionOpportunityId.HasValue)
+            if ( !ConnectionOpportunityId.HasValue )
             {
                 GetConnectionOpportunity();
             }
 
-            if (!ConnectionOpportunityId.HasValue)
+            if ( !ConnectionOpportunityId.HasValue )
             {
                 pnlView.Visible = false;
                 ShowError( "At least one connection opportunity is required before this block can be used" );
@@ -4084,7 +4124,7 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void BindBoardOrGrid()
         {
-            if (IsCardViewMode)
+            if ( IsCardViewMode )
             {
                 upnlBoardView.Visible = true;
                 upnlGridView.Visible = false;
@@ -4126,10 +4166,10 @@ namespace RockWeb.Blocks.Connection
         private void SetControlOnTransfer( ConnectionOpportunity connectionOpportunity, ConnectionRequest connectionRequest )
         {
             ddlRequestModalViewModeTransferModeStatus.Visible = connectionOpportunity.ShowStatusOnTransfer;
-            if (connectionOpportunity.ShowStatusOnTransfer)
+            if ( connectionOpportunity.ShowStatusOnTransfer )
             {
                 ddlRequestModalViewModeTransferModeStatus.Items.Clear();
-                foreach (var status in connectionOpportunity.ConnectionType.ConnectionStatuses)
+                foreach ( var status in connectionOpportunity.ConnectionType.ConnectionStatuses )
                 {
                     ddlRequestModalViewModeTransferModeStatus.Items.Add( new ListItem( status.Name, status.Id.ToString() ) );
                 }
@@ -4138,7 +4178,7 @@ namespace RockWeb.Blocks.Connection
             }
 
             cpTransferCampus.Visible = connectionOpportunity.ShowCampusOnTransfer;
-            if (connectionOpportunity.ShowCampusOnTransfer)
+            if ( connectionOpportunity.ShowCampusOnTransfer )
             {
                 cpTransferCampus.IncludeInactive = false;
                 cpTransferCampus.SetValue( connectionRequest.CampusId );
@@ -4157,23 +4197,23 @@ namespace RockWeb.Blocks.Connection
             ddlRequestModalViewModeTransferModeOpportunityConnector.Items.Clear();
             ddlRequestModalViewModeTransferModeOpportunityConnector.Items.Add( new ListItem() );
 
-            if (connectionOpportunity != null)
+            if ( connectionOpportunity != null )
             {
-                if (connectionOpportunity.ConnectionType != null && connectionRequest != null)
+                if ( connectionOpportunity.ConnectionType != null && connectionRequest != null )
                 {
-                    if (setControl)
+                    if ( setControl )
                     {
                         SetControlOnTransfer( connectionOpportunity, connectionRequest );
                     }
 
                     var campusId = connectionRequest.CampusId;
-                    if (connectionOpportunity.ShowCampusOnTransfer)
+                    if ( connectionOpportunity.ShowCampusOnTransfer )
                     {
                         campusId = cpTransferCampus.SelectedCampusId;
                     }
 
                     var connectionOpportunityConnectorPersonList = new ConnectionOpportunityConnectorGroupService( rockContext ).Queryable()
-                        .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id && (!campusId.HasValue || !a.CampusId.HasValue || a.CampusId.Value == campusId.Value) )
+                        .Where( a => a.ConnectionOpportunityId == connectionOpportunity.Id && ( !campusId.HasValue || !a.CampusId.HasValue || a.CampusId.Value == campusId.Value ) )
                         .SelectMany( a => a.ConnectorGroup.Members )
                         .Where( a => a.GroupMemberStatus == GroupMemberStatus.Active )
                         .Select( a => a.Person )
@@ -4184,7 +4224,7 @@ namespace RockWeb.Blocks.Connection
                 }
 
                 // Add the current person as possible connector
-                if (CurrentPerson != null)
+                if ( CurrentPerson != null )
                 {
                     connectors.AddOrIgnore( CurrentPerson.Id, CurrentPerson );
                 }
@@ -4200,27 +4240,27 @@ namespace RockWeb.Blocks.Connection
             }
 
             int? defaultConnectorPersonId = null;
-            if (connectionRequest != null && connectionOpportunity != null)
+            if ( connectionRequest != null && connectionOpportunity != null )
             {
                 defaultConnectorPersonId = connectionOpportunity.GetDefaultConnectorPersonId( connectionRequest.CampusId );
-                if (defaultConnectorPersonId.HasValue)
+                if ( defaultConnectorPersonId.HasValue )
                 {
                     var defaultConnectorListItem = ddlRequestModalViewModeTransferModeOpportunityConnector.Items.FindByValue( defaultConnectorPersonId.ToString() );
-                    if (defaultConnectorListItem != null)
+                    if ( defaultConnectorListItem != null )
                     {
                         defaultConnectorListItem.Attributes["IsDefaultConnector"] = true.ToTrueFalse();
                     }
                 }
             }
 
-            if (rbRequestModalViewModeTransferModeDefaultConnector.Checked && connectionOpportunity != null)
+            if ( rbRequestModalViewModeTransferModeDefaultConnector.Checked && connectionOpportunity != null )
             {
-                if (defaultConnectorPersonId.HasValue)
+                if ( defaultConnectorPersonId.HasValue )
                 {
                     ddlRequestModalViewModeTransferModeOpportunityConnector.SetValue( defaultConnectorPersonId.Value );
                 }
             }
-            else if (connectionRequest != null && connectionRequest.ConnectorPersonAlias != null)
+            else if ( connectionRequest != null && connectionRequest.ConnectorPersonAlias != null )
             {
                 ddlRequestModalViewModeTransferModeOpportunityConnector.SetValue( connectionRequest.ConnectorPersonAlias.PersonId );
             }
@@ -4294,7 +4334,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<GroupViewModel> GetAvailablePlacementGroups( int? campusId )
         {
-            if (_availablePlacementGroups == null)
+            if ( _availablePlacementGroups == null )
             {
                 var rockContext = new RockContext();
                 var opportunity = GetConnectionOpportunity();
@@ -4352,7 +4392,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private CampusCache GetCampus()
         {
-            if (CampusId.HasValue)
+            if ( CampusId.HasValue )
             {
                 return CampusCache.Get( CampusId.Value );
             }
@@ -4367,7 +4407,7 @@ namespace RockWeb.Blocks.Connection
         {
             HideRequestModalNotification();
 
-            if (!ConnectionRequestId.HasValue)
+            if ( !ConnectionRequestId.HasValue )
             {
                 return;
             }
@@ -4384,7 +4424,7 @@ namespace RockWeb.Blocks.Connection
                 .Include( cr => cr.AssignedGroup )
                 .FirstOrDefault( cr => cr.Id == ConnectionRequestId.Value );
 
-            if (connectionRequest == null || connectionRequest.PersonAlias == null || connectionRequest.ConnectionOpportunity == null)
+            if ( connectionRequest == null || connectionRequest.PersonAlias == null || connectionRequest.ConnectionOpportunity == null )
             {
                 return;
             }
@@ -4393,13 +4433,13 @@ namespace RockWeb.Blocks.Connection
             GroupMember groupMember = null;
 
             // Only do group member placement if the request has an assigned placement group, role, and status
-            if (connectionRequest.AssignedGroupId.HasValue &&
+            if ( connectionRequest.AssignedGroupId.HasValue &&
                 connectionRequest.AssignedGroupMemberRoleId.HasValue &&
-                connectionRequest.AssignedGroupMemberStatus.HasValue)
+                connectionRequest.AssignedGroupMemberStatus.HasValue )
             {
                 var group = connectionRequest.AssignedGroup;
 
-                if (group != null)
+                if ( group != null )
                 {
                     // Only attempt the add if person does not already exist in group with same role
                     groupMember = groupMemberService.GetByGroupIdAndPersonIdAndGroupRoleId(
@@ -4407,7 +4447,7 @@ namespace RockWeb.Blocks.Connection
                         connectionRequest.PersonAlias.PersonId,
                         connectionRequest.AssignedGroupMemberRoleId.Value );
 
-                    if (groupMember == null)
+                    if ( groupMember == null )
                     {
                         groupMember = new GroupMember();
                         groupMember.PersonId = connectionRequest.PersonAlias.PersonId;
@@ -4416,13 +4456,13 @@ namespace RockWeb.Blocks.Connection
                         groupMember.GroupMemberStatus = connectionRequest.AssignedGroupMemberStatus.Value;
                         var groupRequirementLookup = group.GetGroupRequirements( rockContext ).ToList().ToDictionary( k => k.Id );
 
-                        foreach (ListItem item in cblRequestModalViewModeManualRequirements.Items)
+                        foreach ( ListItem item in cblRequestModalViewModeManualRequirements.Items )
                         {
                             var groupRequirementId = item.Value.AsInteger();
                             var groupRequirement = groupRequirementLookup[groupRequirementId];
 
-                            if (!item.Selected &&
-                                (groupRequirement == null || groupRequirement.MustMeetRequirementToAddMember))
+                            if ( !item.Selected &&
+                                ( groupRequirement == null || groupRequirement.MustMeetRequirementToAddMember ) )
                             {
                                 okToConnect = false;
                                 ShowRequestModalNotification(
@@ -4441,16 +4481,16 @@ namespace RockWeb.Blocks.Connection
                             }
                         }
 
-                        if (okToConnect)
+                        if ( okToConnect )
                         {
                             groupMemberService.Add( groupMember );
-                            if (!string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ))
+                            if ( !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ) )
                             {
                                 var savedValues = JsonConvert.DeserializeObject<Dictionary<string, string>>( connectionRequest.AssignedGroupMemberAttributeValues );
-                                if (savedValues != null)
+                                if ( savedValues != null )
                                 {
                                     groupMember.LoadAttributes();
-                                    foreach (var item in savedValues)
+                                    foreach ( var item in savedValues )
                                     {
                                         groupMember.SetAttributeValue( item.Key, item.Value );
                                     }
@@ -4461,7 +4501,7 @@ namespace RockWeb.Blocks.Connection
                 }
             }
 
-            if (okToConnect)
+            if ( okToConnect )
             {
                 // ... but always record the connection activity and change the state to connected.
                 var guid = Rock.SystemGuid.ConnectionActivityType.CONNECTED.AsGuid();
@@ -4470,7 +4510,7 @@ namespace RockWeb.Blocks.Connection
                     .Select( t => t.Id )
                     .FirstOrDefault();
 
-                if (connectedActivityId > 0)
+                if ( connectedActivityId > 0 )
                 {
                     var connectionRequestActivity = new ConnectionRequestActivity();
                     connectionRequestActivity.ConnectionRequestId = connectionRequest.Id;
@@ -4484,7 +4524,7 @@ namespace RockWeb.Blocks.Connection
 
                 rockContext.SaveChanges();
 
-                if (groupMember != null && !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ))
+                if ( groupMember != null && !string.IsNullOrWhiteSpace( connectionRequest.AssignedGroupMemberAttributeValues ) )
                 {
                     groupMember.SaveAttributeValues( rockContext );
                 }
@@ -4496,25 +4536,25 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private void DeleteRequest()
         {
-            if (!ConnectionRequestId.HasValue)
+            if ( !ConnectionRequestId.HasValue )
             {
                 return;
             }
 
-            using (var rockContext = new RockContext())
+            using ( var rockContext = new RockContext() )
             {
                 var service = new ConnectionRequestService( rockContext );
                 var connectionRequest = service.Get( ConnectionRequestId.Value );
-                if (connectionRequest != null)
+                if ( connectionRequest != null )
                 {
                     string errorMessage;
-                    if (!service.CanDelete( connectionRequest, out errorMessage ))
+                    if ( !service.CanDelete( connectionRequest, out errorMessage ) )
                     {
                         ShowError( errorMessage );
                         return;
                     }
 
-                    if (!service.IsAuthorizedToEdit( connectionRequest, CurrentPerson ))
+                    if ( !service.IsAuthorizedToEdit( connectionRequest, CurrentPerson ) )
                     {
                         ShowError( "You are not authorized to delete this Connection Request." );
                         return;
@@ -4538,14 +4578,14 @@ namespace RockWeb.Blocks.Connection
         /// </returns>
         private bool CanEdit()
         {
-            if (UserCanEdit)
+            if ( UserCanEdit )
             {
                 return true;
             }
 
             var opportunity = GetConnectionOpportunity();
 
-            if (opportunity == null)
+            if ( opportunity == null )
             {
                 return false;
             }
@@ -4567,7 +4607,7 @@ namespace RockWeb.Blocks.Connection
             var connectionOpportunityIdParam = PageParameter( PageParameterKey.ConnectionOpportunityId ).AsIntegerOrNull();
             var campusIdParam = PageParameter( PageParameterKey.CampusId ).AsIntegerOrNull();
 
-            if (!ConnectionOpportunityId.HasValue && connectionRequestIdParam.HasValue)
+            if ( !ConnectionOpportunityId.HasValue && connectionRequestIdParam.HasValue )
             {
                 var rockContext = new RockContext();
                 var connectionRequestService = new ConnectionRequestService( rockContext );
@@ -4581,7 +4621,7 @@ namespace RockWeb.Blocks.Connection
                     } )
                     .FirstOrDefault();
 
-                if (result != null && availableOpportunityIds.Contains( result.ConnectionOpportunityId ))
+                if ( result != null && availableOpportunityIds.Contains( result.ConnectionOpportunityId ) )
                 {
                     ConnectionOpportunityId = result.ConnectionOpportunityId;
                     ConnectionRequestId = connectionRequestIdParam.Value;
@@ -4593,27 +4633,27 @@ namespace RockWeb.Blocks.Connection
             }
 
             // If the opportunity is not yet set by the request id param, then set it
-            if (!ConnectionOpportunityId.HasValue &&
+            if ( !ConnectionOpportunityId.HasValue &&
                 connectionOpportunityIdParam.HasValue &&
-                availableOpportunityIds.Contains( connectionOpportunityIdParam.Value ))
+                availableOpportunityIds.Contains( connectionOpportunityIdParam.Value ) )
             {
                 ConnectionOpportunityId = connectionOpportunityIdParam.Value;
                 ConnectionRequestId = null;
                 ViewAllActivities = false;
                 IsRequestModalAddEditMode = false;
                 RequestModalViewModeSubMode = RequestModalViewModeSubMode_View;
-                if (campusIdParam.HasValue)
+                if ( campusIdParam.HasValue )
                 {
                     SaveSettingByConnectionType( UserPreferenceKey.CampusFilter, campusIdParam.ToString() );
                 }
             }
 
             // If the opportunity is not yet set by the request or opportunity id params, then set it from preference
-            if (!ConnectionOpportunityId.HasValue)
+            if ( !ConnectionOpportunityId.HasValue )
             {
                 var userPreferenceOpportunityId = GetBlockUserPreference( UserPreferenceKey.ConnectionOpportunityId ).AsIntegerOrNull();
 
-                if (userPreferenceOpportunityId.HasValue && availableOpportunityIds.Contains( userPreferenceOpportunityId.Value ))
+                if ( userPreferenceOpportunityId.HasValue && availableOpportunityIds.Contains( userPreferenceOpportunityId.Value ) )
                 {
                     ConnectionOpportunityId = userPreferenceOpportunityId;
                 }
@@ -4629,7 +4669,7 @@ namespace RockWeb.Blocks.Connection
             // Load the sort property
             ConnectionRequestViewModelSortProperty sortProperty;
 
-            if (Enum.TryParse( LoadSettingByConnectionType( UserPreferenceKey.SortBy ), out sortProperty ))
+            if ( Enum.TryParse( LoadSettingByConnectionType( UserPreferenceKey.SortBy ), out sortProperty ) )
             {
                 CurrentSortProperty = sortProperty;
             }
@@ -4654,7 +4694,7 @@ namespace RockWeb.Blocks.Connection
         {
             var key = GetKeyForSettingByConnectionType( subKey );
 
-            if (key.IsNullOrWhiteSpace())
+            if ( key.IsNullOrWhiteSpace() )
             {
                 return string.Empty;
             }
@@ -4672,7 +4712,7 @@ namespace RockWeb.Blocks.Connection
         {
             var key = GetKeyForSettingByConnectionType( subKey );
 
-            if (key.IsNullOrWhiteSpace())
+            if ( key.IsNullOrWhiteSpace() )
             {
                 return;
             }
@@ -4689,7 +4729,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if (connectionOpportunity == null)
+            if ( connectionOpportunity == null )
             {
                 return string.Empty;
             }
@@ -4721,13 +4761,13 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private ConnectionRequestActivity GetCurrentActivity()
         {
-            if (!CurrentActivityId.HasValue)
+            if ( !CurrentActivityId.HasValue )
             {
                 _connectionRequestActivity = null;
                 return null;
             }
 
-            if (_connectionRequestActivity != null && _connectionRequestActivity.Id == CurrentActivityId)
+            if ( _connectionRequestActivity != null && _connectionRequestActivity.Id == CurrentActivityId )
             {
                 return _connectionRequestActivity;
             }
@@ -4747,12 +4787,12 @@ namespace RockWeb.Blocks.Connection
         private ConnectionRequestViewModel GetConnectionRequestViewModel()
         {
             // Do not make a db call if the id and current record are in sync
-            if (_connectionRequestViewModel != null && _connectionRequestViewModel.Id == ConnectionRequestId)
+            if ( _connectionRequestViewModel != null && _connectionRequestViewModel.Id == ConnectionRequestId )
             {
                 return _connectionRequestViewModel;
             }
 
-            if (!ConnectionRequestId.HasValue)
+            if ( !ConnectionRequestId.HasValue )
             {
                 _connectionRequestViewModel = null;
                 return _connectionRequestViewModel;
@@ -4778,13 +4818,13 @@ namespace RockWeb.Blocks.Connection
         {
             var viewModel = GetConnectionRequestViewModel();
 
-            if (viewModel == null)
+            if ( viewModel == null )
             {
                 _requesterPerson = null;
                 return null;
             }
 
-            if (_requesterPerson != null && _requesterPerson.Id == viewModel.PersonId)
+            if ( _requesterPerson != null && _requesterPerson.Id == viewModel.PersonId )
             {
                 return _requesterPerson;
             }
@@ -4804,12 +4844,12 @@ namespace RockWeb.Blocks.Connection
         private ConnectionRequest GetConnectionRequest()
         {
             // Do not make a db call if the id and current record are in sync
-            if (_connectionRequest != null && _connectionRequest.Id == ConnectionRequestId)
+            if ( _connectionRequest != null && _connectionRequest.Id == ConnectionRequestId )
             {
                 return _connectionRequest;
             }
 
-            if (!ConnectionRequestId.HasValue)
+            if ( !ConnectionRequestId.HasValue )
             {
                 _connectionRequest = null;
                 return _connectionRequest;
@@ -4840,7 +4880,7 @@ namespace RockWeb.Blocks.Connection
         private ConnectionOpportunity GetConnectionOpportunity()
         {
             // Do not make a db call if the id and current record are in sync
-            if (_connectionOpportunity != null && _connectionOpportunity.Id == ConnectionOpportunityId)
+            if ( _connectionOpportunity != null && _connectionOpportunity.Id == ConnectionOpportunityId )
             {
                 return _connectionOpportunity;
             }
@@ -4865,7 +4905,7 @@ namespace RockWeb.Blocks.Connection
                 query.FirstOrDefault();
 
             // Select the first record if one is not explicitly selected
-            if (!ConnectionOpportunityId.HasValue && _connectionOpportunity != null)
+            if ( !ConnectionOpportunityId.HasValue && _connectionOpportunity != null )
             {
                 ConnectionOpportunityId = _connectionOpportunity.Id;
                 ConnectionRequestId = null;
@@ -4883,7 +4923,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<ConnectionTypeViewModel> GetConnectionTypeViewModels()
         {
-            if (_connectionTypeViewModels == null)
+            if ( _connectionTypeViewModels == null )
             {
                 var rockContext = new RockContext();
                 var connectionTypeService = new ConnectionTypeService( rockContext );
@@ -4893,7 +4933,7 @@ namespace RockWeb.Blocks.Connection
                     .Include( ct => ct.ConnectionOpportunities )
                     .Where( ct => ct.IsActive );
 
-                if (typeGuidsFilter.Any())
+                if ( typeGuidsFilter.Any() )
                 {
                     query = query.Where( ct => typeGuidsFilter.Contains( ct.Guid ) );
                 }
@@ -4946,7 +4986,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if (connectionOpportunity == null)
+            if ( connectionOpportunity == null )
             {
                 return new List<ConnectionOpportunityViewModel>();
             }
@@ -4954,7 +4994,7 @@ namespace RockWeb.Blocks.Connection
             var connectionTypes = GetConnectionTypeViewModels();
             var connectionType = connectionTypes.FirstOrDefault( ct => ct.Id == connectionOpportunity.ConnectionTypeId );
 
-            if (connectionType == null)
+            if ( connectionType == null )
             {
                 return new List<ConnectionOpportunityViewModel>();
             }
@@ -4990,7 +5030,7 @@ namespace RockWeb.Blocks.Connection
                 } )
                 .ToList();
 
-            if (includeCurrentPerson && CurrentPersonAliasId.HasValue && !connectors.Any( c => c.PersonAliasId == CurrentPersonAliasId ))
+            if ( includeCurrentPerson && CurrentPersonAliasId.HasValue && !connectors.Any( c => c.PersonAliasId == CurrentPersonAliasId ) )
             {
                 connectors.Add( new ConnectorViewModel
                 {
@@ -5000,12 +5040,12 @@ namespace RockWeb.Blocks.Connection
                 } );
             }
 
-            if (personAliasIdToInclude.HasValue && !connectors.Any( c => c.PersonAliasId == personAliasIdToInclude ))
+            if ( personAliasIdToInclude.HasValue && !connectors.Any( c => c.PersonAliasId == personAliasIdToInclude ) )
             {
                 var personAliasService = new PersonAliasService( rockContext );
                 var person = personAliasService.GetPerson( personAliasIdToInclude.Value );
 
-                if (person != null)
+                if ( person != null )
                 {
                     connectors.Add( new ConnectorViewModel
                     {
@@ -5032,7 +5072,7 @@ namespace RockWeb.Blocks.Connection
             var requesterPersonAliasId = ppRequesterFilter.PersonAliasId;
             var statuses = cblStatusFilter.SelectedValuesAsInt;
             var states = cblStateFilter.SelectedValues
-                .Select( s => (ConnectionState) Enum.Parse( typeof( ConnectionState ), s ) )
+                .Select( s => ( ConnectionState ) Enum.Parse( typeof( ConnectionState ), s ) )
                 .ToList();
             var activityTypeIds = cblLastActivityFilter.SelectedValuesAsInt;
 
@@ -5062,15 +5102,15 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if (connectionOpportunity == null)
+            if ( connectionOpportunity == null )
             {
                 _connectionActivityTypes = null;
                 return null;
             }
 
-            if (_connectionActivityTypes != null &&
+            if ( _connectionActivityTypes != null &&
                 _connectionActivityTypes.Any() &&
-                _connectionActivityTypes.FirstOrDefault().ConnectionTypeId == connectionOpportunity.ConnectionTypeId)
+                _connectionActivityTypes.FirstOrDefault().ConnectionTypeId == connectionOpportunity.ConnectionTypeId )
             {
                 return _connectionActivityTypes;
             }
@@ -5099,20 +5139,20 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private Rock.Model.Group GetPlacementGroup( int? groupId )
         {
-            if (!groupId.HasValue)
+            if ( !groupId.HasValue )
             {
                 return null;
             }
 
             var group = _placementGroups.GetValueOrNull( groupId.Value );
 
-            if (group == null)
+            if ( group == null )
             {
                 var rockContext = new RockContext();
                 var groupService = new GroupService( rockContext );
                 group = groupService.GetNoTracking( groupId.Value );
 
-                if (group != null)
+                if ( group != null )
                 {
                     _placementGroups[groupId.Value] = group;
                 }
@@ -5150,7 +5190,7 @@ namespace RockWeb.Blocks.Connection
             // Parse the attribute filters
             var connectionOpportunity = GetConnectionOpportunity();
 
-            if (connectionOpportunity == null)
+            if ( connectionOpportunity == null )
             {
                 return new List<AttributeCache>();
             }
@@ -5193,7 +5233,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionRequestViewModel = GetConnectionRequestViewModel();
 
-            if (connectionRequestViewModel == null)
+            if ( connectionRequestViewModel == null )
             {
                 return new List<ActivityViewModel>().AsQueryable();
             }
@@ -5205,7 +5245,7 @@ namespace RockWeb.Blocks.Connection
                 .AsNoTracking()
                 .Where( a => a.ConnectionRequest.PersonAliasId == connectionRequestViewModel.PersonAliasId );
 
-            if (connectionType.EnableFullActivityList)
+            if ( connectionType.EnableFullActivityList )
             {
                 query = query.Where( a => a.ConnectionOpportunity.ConnectionTypeId == connectionType.Id );
             }
@@ -5242,7 +5282,7 @@ namespace RockWeb.Blocks.Connection
         {
             var connectionType = GetConnectionType();
 
-            if (connectionType == null)
+            if ( connectionType == null )
             {
                 return new List<ConnectionActivityType>().AsQueryable();
             }
@@ -5262,7 +5302,7 @@ namespace RockWeb.Blocks.Connection
         /// <returns></returns>
         private List<PersonGroupRequirementStatus> GetGroupRequirementStatuses( ConnectionRequestViewModel request )
         {
-            if (request == null || !request.PlacementGroupId.HasValue)
+            if ( request == null || !request.PlacementGroupId.HasValue )
             {
                 return new List<PersonGroupRequirementStatus>();
             }
@@ -5271,14 +5311,14 @@ namespace RockWeb.Blocks.Connection
             var key = string.Format( "{0}-{1}", request.PersonId, groupId );
             var requirementsResults = _groupRequirementStatuses.GetValueOrNull( key );
 
-            if (requirementsResults != null)
+            if ( requirementsResults != null )
             {
                 return requirementsResults.ToList();
             }
 
             var group = GetPlacementGroup( groupId );
 
-            if (group == null)
+            if ( group == null )
             {
                 requirementsResults = new List<PersonGroupRequirementStatus>();
             }
@@ -5287,7 +5327,7 @@ namespace RockWeb.Blocks.Connection
                 var rockContext = new RockContext();
                 requirementsResults = group.PersonMeetsGroupRequirements( rockContext, request.PersonId, request.PlacementGroupRoleId );
 
-                if (requirementsResults != null)
+                if ( requirementsResults != null )
                 {
                     // Ignore the NotApplicable requirements.
                     requirementsResults = requirementsResults.Where( r => r.MeetsGroupRequirement != MeetsGroupRequirement.NotApplicable );
@@ -5417,7 +5457,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( string value )
         {
-            if (value == null)
+            if ( value == null )
             {
                 return "null";
             }
@@ -5431,7 +5471,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( DateTime? value )
         {
-            if (!value.HasValue)
+            if ( !value.HasValue )
             {
                 return "null";
             }
@@ -5445,7 +5485,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( int? value )
         {
-            if (!value.HasValue)
+            if ( !value.HasValue )
             {
                 return "null";
             }
@@ -5459,7 +5499,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The values.</param>
         private string ToJavaScript( List<int> values )
         {
-            if (values == null)
+            if ( values == null )
             {
                 return "null";
             }
@@ -5473,7 +5513,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The value.</param>
         private string ToJavaScript( bool? value )
         {
-            if (!value.HasValue)
+            if ( !value.HasValue )
             {
                 return "null";
             }
@@ -5487,7 +5527,7 @@ namespace RockWeb.Blocks.Connection
         /// <param name="value">The values.</param>
         private string ToJavaScript( List<string> values )
         {
-            if (values == null)
+            if ( values == null )
             {
                 return "null";
             }

--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -157,6 +157,13 @@ namespace RockWeb.Blocks.Connection
         Order = 15,
         Key = AttributeKey.ConnectionRequestHistoryPage )]
 
+    [SecurityRoleField(
+        "Safety & Security Role",
+        Description = "If set, only members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect.",
+        IsRequired = false,
+        Order = 30,
+        Key = AttributeKey.SafetySecurityRole )]
+
     #endregion Block Attributes
 
     [ContextAware( typeof( Person ), IsConfigurable = false )]
@@ -250,6 +257,7 @@ namespace RockWeb.Blocks.Connection
             public const string WorkflowEntryPage = "WorkflowEntryPage";
             public const string StatusTemplate = "StatusTemplate";
             public const string ConnectionRequestHistoryPage = "ConnectionRequestHistoryPage";
+            public const string SafetySecurityRole = "SafetySecurityRole";
         }
 
         /// <summary>
@@ -2466,6 +2474,12 @@ namespace RockWeb.Blocks.Connection
                 return true;
             }
 
+            // ROCK-8640: enforce S&S role gate before the empty-status short-circuit
+            if (!UserIsAuthorizedToConnect())
+            {
+                return false;
+            }
+
             var connectableStatuses = connectionOpportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
                 .Select( v => v.AsIntegerOrNull() )
                 .Where( v => v.HasValue )
@@ -2480,9 +2494,34 @@ namespace RockWeb.Blocks.Connection
             var connectionRequest = GetConnectionRequest();
 
             return connectableStatuses.Contains( connectionRequest.ConnectionStatusId ) || connectionRequest.ConnectionState == ConnectionState.Connected;
+        }
 
+        /// <summary>
+        /// True if the current person may bypass or satisfy the S&S connect gate:
+        /// Rock Administrators always may; otherwise the person must be in the configured S&S role.
+        /// If no S&S role is configured, only Rock Administrators pass.
+        /// </summary>
+        private bool UserIsAuthorizedToConnect()
+        {
+            if ( CurrentPerson == null )
+            {
+                return false;
+            }
 
+            var adminRole = RoleCache.Get( Rock.SystemGuid.Group.GROUP_ADMINISTRATORS.AsGuid() );
+            if ( adminRole != null && adminRole.IsPersonInRole( CurrentPerson.Guid ) )
+            {
+                return true;
+            }
 
+            var roleGuid = GetAttributeValue( AttributeKey.SafetySecurityRole ).AsGuidOrNull();
+            if ( !roleGuid.HasValue )
+            {
+                return false;
+            }
+
+            var ssRole = RoleCache.Get( roleGuid.Value );
+            return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
         }
 
         private bool CanUserEditConnectionRequest()

--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
@@ -2074,17 +2074,20 @@ namespace RockWeb.Blocks.Connection
         }
 
         /// <summary>
-        /// Shows the readonly details.
-        /// </summary>
-        /// <param name="connectionRequest">The connection request.</param>
-        /// <summary>
-        /// Returns true if the current request satisfies the S&S connect gate for the opportunity.
+        /// SECC: Returns true if the current request satisfies the S&amp;S connect gate for the opportunity.
+        /// Fails closed: returns false if the opportunity cannot be resolved.
         /// </summary>
         private bool CanUserConnect( ConnectionRequest connectionRequest )
         {
             var opportunity = connectionRequest.ConnectionOpportunity;
+
+            if ( opportunity == null )
+            {
+                return false;
+            }
+
             opportunity.LoadAttributes();
-            var requiresSecurityToConnect = opportunity.GetAttributeValue( "SecurityToConnect" ).AsBooleanOrNull();
+            var requiresSecurityToConnect = GetRequiresSecurityToConnect( opportunity );
 
             if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
             {
@@ -2108,6 +2111,31 @@ namespace RockWeb.Blocks.Connection
 
             return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
                 || connectionRequest.ConnectionState == ConnectionState.Connected;
+        }
+
+        // ROCK-8640: attribute keys for the SecurityToConnect flag across all opportunity types.
+        private static readonly string[] SecurityToConnectAttributeKeys =
+        {
+            "SecurityToConnect",
+            "RequireSafetySecuritytoConnect",      // RISE
+            "RequireSafetyandSecuritytoConnect"    // Lightning Lane
+        };
+
+        /// <summary>
+        /// SECC: Returns the first non-null SecurityToConnect value found across all known attribute keys.
+        /// </summary>
+        private static bool? GetRequiresSecurityToConnect( ConnectionOpportunity opportunity )
+        {
+            foreach ( var key in SecurityToConnectAttributeKeys )
+            {
+                var value = opportunity.GetAttributeValue( key ).AsBooleanOrNull();
+                if ( value.HasValue )
+                {
+                    return value;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -2138,6 +2166,10 @@ namespace RockWeb.Blocks.Connection
             return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
         }
 
+        /// <summary>
+        /// Shows the readonly details.
+        /// </summary>
+        /// <param name="connectionRequest">The connection request.</param>
         private void ShowReadonlyDetails( ConnectionRequest connectionRequest )
         {
             pdAuditDetails.SetEntity( connectionRequest, ResolveRockUrl( "~" ) );

--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
@@ -99,6 +99,13 @@ namespace RockWeb.Blocks.Connection
         IsRequired = false,
         Order = 8 )]
 
+    [SecurityRoleField(
+        "Safety & Security Role",
+        Description = "If set, only members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect.",
+        IsRequired = false,
+        Order = 9,
+        Key = AttributeKeys.SafetySecurityRole )]
+
     #endregion Block Attributes
 
     public partial class ConnectionRequestDetail : PersonBlock
@@ -116,6 +123,7 @@ namespace RockWeb.Blocks.Connection
             public const string LavaBadgeBar = "LavaBadgeBar";
             public const string LavaHeadingTemplate = "LavaHeadingTemplate";
             public const string ActivityLavaTemplate = "Activity Lava Template";
+            public const string SafetySecurityRole = "SafetySecurityRole";
         }
 
         #endregion Attribute Keys
@@ -2069,6 +2077,67 @@ namespace RockWeb.Blocks.Connection
         /// Shows the readonly details.
         /// </summary>
         /// <param name="connectionRequest">The connection request.</param>
+        /// <summary>
+        /// Returns true if the current request satisfies the S&S connect gate for the opportunity.
+        /// </summary>
+        private bool CanUserConnect( ConnectionRequest connectionRequest )
+        {
+            var opportunity = connectionRequest.ConnectionOpportunity;
+            opportunity.LoadAttributes();
+            var requiresSecurityToConnect = opportunity.GetAttributeValue( "SecurityToConnect" ).AsBooleanOrNull();
+
+            if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
+            {
+                return true;
+            }
+
+            if ( !UserIsAuthorizedToConnect() )
+            {
+                return false;
+            }
+
+            var connectableStatuses = opportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
+                .Select( v => v.AsIntegerOrNull() )
+                .Where( v => v.HasValue )
+                .ToList();
+
+            if ( connectableStatuses.Count == 0 )
+            {
+                return true;
+            }
+
+            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
+                || connectionRequest.ConnectionState == ConnectionState.Connected;
+        }
+
+        /// <summary>
+        /// True if the current person may bypass or satisfy the S&S connect gate:
+        /// Rock Administrators always may; otherwise the person must be in the configured S&S role.
+        /// If no S&S role is configured, only Rock Administrators pass.
+        /// </summary>
+        private bool UserIsAuthorizedToConnect()
+        {
+            if ( CurrentPerson == null )
+            {
+                return false;
+            }
+
+            var adminRole = RoleCache.Get( Rock.SystemGuid.Group.GROUP_ADMINISTRATORS.AsGuid() );
+            if ( adminRole != null && adminRole.IsPersonInRole( CurrentPerson.Guid ) )
+            {
+                return true;
+            }
+
+            var roleGuid = GetAttributeValue( AttributeKeys.SafetySecurityRole ).AsGuidOrNull();
+            if ( !roleGuid.HasValue )
+            {
+                return false;
+            }
+
+            var ssRole = RoleCache.Get( roleGuid.Value );
+            return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
+        }
+
         private void ShowReadonlyDetails( ConnectionRequest connectionRequest )
         {
             pdAuditDetails.SetEntity( connectionRequest, ResolveRockUrl( "~" ) );
@@ -2091,6 +2160,12 @@ namespace RockWeb.Blocks.Connection
             }
 
             if ( !connectionRequest.ConnectionOpportunity.ShowConnectButton )
+            {
+                lbConnect.Visible = false;
+            }
+
+            // ROCK-8640: enforce S&S connect gate on the standalone detail screen
+            if ( !CanUserConnect( connectionRequest ) )
             {
                 lbConnect.Visible = false;
             }


### PR DESCRIPTION
## Summary

This PR lands two related commits that together complete the Safety & Security connect-button visibility gate on the Connection blocks.

**Commit 1 — Chris Funk's S&S foundation** (`2f17d48d9b`)
Introduces the `CanUserConnect()` method on the Connection Request Board block, along with support for the `SecurityToConnect` and `ConnectableStatuses` opportunity attributes. This logic was never pushed to origin and is a prerequisite for the ROCK-8640 changes below.

**Commit 2 — ROCK-8640: Role gate + Rock Admin bypass**
- **Board block** (`ConnectionRequestBoard.ascx.cs`): Extended `CanUserConnect()` to call a new `UserIsAuthorizedToConnect()` helper before the `ConnectableStatuses` short-circuit. Added a `Safety & Security Role` block setting.
- **Detail block** (`ConnectionRequestDetail.ascx.cs`): Ported `CanUserConnect(request)` + `UserIsAuthorizedToConnect()` from the Board — the Detail screen had no gate at all previously. Added the same `Safety & Security Role` block setting and wired the gate into `ShowReadonlyDetails()`.
- **Rock Administrators** (system GUID `628C51A8-4613-43ED-A18D-4A6FB999273E`) always pass the gate — no block setting needed, no lockout risk.
- `SecurityToConnect` and `ConnectableStatuses` attributes are **unchanged**.

## Post-deploy configuration

After deploying, configure the **Safety & Security Role** block setting on both the Connection Request Board and Connection Request Detail blocks, pointing to the S&S Workers role for that environment. The Rock Administrators bypass is automatic and requires no configuration.

## Test plan

- [ ] Rock Administrator — Connect button shows on both Board modal and Detail in any connectable status (admin bypass)
- [ ] S&S Workers member (non-admin) — Connect button shows when request is in a connectable status; hidden otherwise
- [ ] Non-S&S, non-admin user with edit rights — Connect button hidden on both Board and Detail regardless of status
- [ ] Non-secured opportunity (`SecurityToConnect = False`) — no regression, Connect behaves as before for all users
- [ ] Already-Connected or Inactive requests still hide Connect
- [ ] `ShowConnectButton = false` still hides Connect
- [ ] Secured opportunity with empty `ConnectableStatuses` — now restricted to S&S Workers + admins (previously open to everyone)

## Rollback

- Revert this PR merge to remove both changes.
- No database migration to roll back — `SecurityToConnect` and `ConnectableStatuses` were not modified.