### PR TITLE
ROCK-8640 Hide ungated Connect action on Connection Request Board cards

### DIFF
--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -2526,6 +2526,25 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private bool CanUserConnect()
         {
+            var connectionRequest = GetConnectionRequest();
+
+            // Add mode: no request yet - don't block modal rendering.
+            if ( connectionRequest == null )
+            {
+                return CanUserConnect( null, null );
+            }
+
+            return CanUserConnect( connectionRequest.ConnectionStatusId, connectionRequest.ConnectionState );
+        }
+
+        /// <summary>
+        /// SECC: The single implementation of the connect gate. The status and state are parameters so the
+        /// same rule can be evaluated for the request in context (the modal's Connect button) and for an
+        /// arbitrary status (the board card action menu), without a second copy of the logic.
+        /// A null status means there is no request in context.
+        /// </summary>
+        private bool CanUserConnect( int? connectionStatusId, ConnectionState? connectionState )
+        {
             var connectionOpportunity = GetConnectionOpportunity();
 
             if ( connectionOpportunity == null )
@@ -2556,16 +2575,43 @@ namespace RockWeb.Blocks.Connection
                 return true;
             }
 
-            var connectionRequest = GetConnectionRequest();
-
-            // Add mode: no request yet — don't block modal rendering.
-            if ( connectionRequest == null )
+            // No request in context: don't block modal rendering.
+            if ( !connectionStatusId.HasValue )
             {
                 return true;
             }
 
-            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
-                || connectionRequest.ConnectionState == ConnectionState.Connected;
+            return connectableStatuses.Contains( connectionStatusId.Value )
+                || connectionState == ConnectionState.Connected;
+        }
+
+        /// <summary>
+        /// SECC: Runs the gate above against every status on the selected opportunity, so the board card
+        /// action menu can hide its Connect item using exactly the same rule that hides the Connect button
+        /// on the request modal. Presentation only - the card menu still posts back to the server.
+        /// </summary>
+        private List<int> GetUserConnectableStatusIds()
+        {
+            var statusIds = new List<int>();
+            var connectionOpportunity = GetConnectionOpportunity();
+
+            if ( connectionOpportunity == null
+                || connectionOpportunity.ConnectionType == null
+                || connectionOpportunity.ConnectionType.ConnectionStatuses == null )
+            {
+                return statusIds;
+            }
+
+            foreach ( var connectionStatus in connectionOpportunity.ConnectionType.ConnectionStatuses )
+            {
+                // Cards never render for Connected or Inactive requests, so evaluate each status as Active.
+                if ( CanUserConnect( connectionStatus.Id, ConnectionState.Active ) )
+                {
+                    statusIds.Add( connectionStatus.Id );
+                }
+            }
+
+            return statusIds;
         }
 
         /// <summary>
@@ -5374,7 +5420,8 @@ namespace RockWeb.Blocks.Connection
     statusIds: {8},
     connectionStates: {9},
     campusId: {10},
-    pastDueOnly: {11}
+    pastDueOnly: {11},
+    userConnectableStatusIds: {12}
 }});",
                 ToJavaScript( ConnectionRequestId ), // 0
                 ToJavaScript( whitespaceRemovedTemplate ), // 1
@@ -5387,7 +5434,8 @@ namespace RockWeb.Blocks.Connection
                 ToJavaScript( cblStatusFilter.SelectedValuesAsInt ), // 8
                 ToJavaScript( cblStateFilter.SelectedValues ), // 9
                 ToJavaScript( CampusId ), // 10
-                ToJavaScript( rcbPastDueOnly.Checked ) /* 11 */ );
+                ToJavaScript( rcbPastDueOnly.Checked ), // 11
+                ToJavaScript( GetUserConnectableStatusIds() ) /* 12 */ );
 
             ScriptManager.RegisterStartupScript(
                 upnlJavaScript,
@@ -5423,7 +5471,8 @@ namespace RockWeb.Blocks.Connection
     lastActivityTypeIds: {11},
     controlClientId: {12},
     pastDueOnly: {13},
-    connectionRequestId: {14}
+    connectionRequestId: {14},
+    userConnectableStatusIds: {15}
 }});",
                 ToJavaScript( ConnectionOpportunityId ), // 0
                 ToJavaScript( GetMaxCardsPerColumn() ), // 1
@@ -5439,7 +5488,8 @@ namespace RockWeb.Blocks.Connection
                 ToJavaScript( cblLastActivityFilter.SelectedValuesAsInt ), // 11
                 ToJavaScript( lbJavaScriptCommand.ClientID ), // 12
                 ToJavaScript( rcbPastDueOnly.Checked ), //13
-                ToJavaScript( ConnectionRequestId ) /* 14 */ );
+                ToJavaScript( ConnectionRequestId ), // 14
+                ToJavaScript( GetUserConnectableStatusIds() ) /* 15 */ );
 
             ScriptManager.RegisterStartupScript(
                 upnlJavaScript,

--- a/RockWeb/Scripts/Rock/Controls/ConnectionRequestBoard/connectionRequestBoard.js
+++ b/RockWeb/Scripts/Rock/Controls/ConnectionRequestBoard/connectionRequestBoard.js
@@ -83,8 +83,34 @@
         };
         let _cardTemplate = '';
 
+        // ROCK-8640: the card action menu's Connect item is driven by the core CanConnect value, which knows
+        // nothing about the SECC Safety & Security gate. The server evaluates that gate (the same method that
+        // hides the Connect button on the request modal) for every status on the opportunity and sends the
+        // allowed status ids here, so this only has to check membership - no gate logic lives in JavaScript.
+        let _userConnectableStatusIds = null;
+
+        const captureConnectGate = function (options) {
+            if (options && options.userConnectableStatusIds) {
+                _userConnectableStatusIds = options.userConnectableStatusIds;
+            }
+        };
+
+        const applyConnectGate = function (viewModel) {
+            if (!viewModel || viewModel.CanConnect !== true || !_userConnectableStatusIds) {
+                return viewModel;
+            }
+
+            if (_userConnectableStatusIds.indexOf(viewModel.StatusId) !== -1) {
+                return viewModel;
+            }
+
+            const gated = $.extend({}, viewModel);
+            gated.CanConnect = false;
+            return gated;
+        };
+
         const getCardHtml = function (requestViewModel) {
-            return resolveTemplateFields(getCardTemplate(), requestViewModel);
+            return resolveTemplateFields(getCardTemplate(), applyConnectGate(requestViewModel));
         };
 
         const getSentryTemplate = function () {
@@ -248,6 +274,8 @@
             if (!options || !options.connectionRequestId) {
                 return
             }
+
+            captureConnectGate(options);
 
             fetchRequestViewModel(options, function (requestViewModel) {
                 refreshCard(options.connectionRequestId, requestViewModel);
@@ -643,6 +671,10 @@
             if (!options || !options.connectionOpportunityId || !options.controlClientId) {
                 throw 'A valid options object is required';
             }
+
+            // ROCK-8640: capture before the early return below, so the gate is applied even when the board
+            // itself does not need re-rendering.
+            captureConnectGate(options);
 
             // Check if this options object has already been initialized (no need to do it again)
             const newOptionsHash = JSON.stringify(options);


### PR DESCRIPTION
## Problem

PR #4 gated the Connect button on the request modal, but the kanban card's action menu ("...") has a second Connect item that PR #4 did not cover:

```html
<!-- ConnectionRequestBoard.ascx:760 -->
<li class="can-connect-{{CanConnect}}">
    <a href="javascript:void(0);" class="js-connect">Connect</a>
</li>
```

That item is rendered client-side from core `ConnectionRequestService.CanConnect()` — placement group assigned, state not Connected/Inactive, `ShowConnectButton` — which knows nothing about `SecurityToConnect`, `ConnectableStatuses`, or the `SafetySecurityRole` block setting. So it stayed visible on secured opportunities at any status, and `.js-connect` posts `action=connect` straight to `MarkRequestConnected()`.

Reproduced on DEV by impersonating a non-S&S connector: the modal Connect button is correctly hidden and the edit-modal state radio correctly reverts, while Connect is present in the card dropdown.

**Scope on prod:** 1,161 cards currently render the item; 1,149 are on secured opportunities and 1,006 are at a status where the gate would deny. It is visible to the ~697 accounts that can view the board (`RSR - Rock Edit Access` / `Staff Like Workers` / `Data Integrity Worker`), not just to assigned connectors.

## Change

- `CanUserConnect()` split into a wrapper plus `CanUserConnect( int?, ConnectionState? )`, so the per-request inputs are parameters and there is exactly **one** gate implementation. Existing callers (modal button, edit-modal Connected guard) are unchanged in behavior.
- `GetUserConnectableStatusIds()` runs that same gate against each status on the selected opportunity and returns the allowed ids.
- Those ids are added to both board script payloads (`initialize`, `fetchAndRefreshCard`), so cards stay gated after a drag or status change.
- `connectionRequestBoard.js` checks membership only — no gate logic in JavaScript. A card whose status is not in the list gets `CanConnect = false`, so the existing `.can-connect-false { display: none }` rule hides the menu item.

Net effect: the card menu hides its Connect item under exactly the rule that hides the modal button. Change the gate later and the card menu follows automatically.

## Verification

- `node --check` passes on the JS.
- Both `string.Format` payloads checked line by line against their argument lists (0–12 and 0–15).
- Stays within C# 6 — `RockWeb/web.config` pins `/langversion:6` and RockWeb is a Web Site project, so this block compiles at runtime.
- Only two payload sites exist in the block; both updated. `StatusId` is populated by both REST feeds (`ConnectionRequestService.cs:405`). `CanConnect` has exactly one consumer in the markup. No minified copy of the JS to keep in sync.
- **Not compiled** — no solution/msbuild available in the working clone. Needs a build check before deploy.

## Deliberately not in this PR

- **Server-side enforcement.** This is visibility only; the `<li>` remains in the DOM and the postback still reaches `MarkRequestConnected()`. Note `hotfix-1.16.12` already enforces the gate on `action=connect` and on `btnRequestModalViewModeConnect_Click`; 13.7 does not. Follow-up.
- Group-requirement validation on the card path — `okToConnect` only inspects the modal's manual-requirement checkboxes, which are empty when the connect comes from a card, so requirements are not enforced there.
- `ConnectionRequestDetail.ascx.cs` — `lbConnect_Click` has no server check, and the `rblState` save at :687 has no Connected guard.
- `ProcessConfirmedDragEvent` — anyone can still drag a card into *Approved (SECURITY USE ONLY)*.
- Opportunity 153 *Guest Experience* config: `ConnectableStatuses = 2` is a CT1 status on a CT10 opportunity, so no request there can ever match.

## Notes for reviewers

- The wrapper now resolves the request before the opportunity, where the original did it last. Same outcome except when no opportunity is selected, where the original failed open and this fails closed.
- Absent `userConnectableStatusIds` (stale cached JS) means "not told", and the gate is skipped — so cache skew behaves as today rather than hiding Connect from S&S. An empty array is truthy in JS, so an unauthorized user still gets every card hidden.
- Evaluating each status as `Active` is safe: state only affects the gate via `== Connected`, so `FutureFollowUp` behaves identically.
- Once enforcement is added, denials need user feedback — the card path never opens the modal, so `ShowRequestModalNotification` is invisible there. The v16 branch currently returns silently.
- This needs an independent port to the v16 line; PR #5 re-implemented the gate there rather than merging from 13.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
