### PR TITLE
ROCK-8640 Hide ungated Connect action on Connection Request Board cards

### DIFF
--- a/RockWeb/App_Code/SeccConnectGateHelper.cs
+++ b/RockWeb/App_Code/SeccConnectGateHelper.cs
@@ -95,6 +95,22 @@ namespace RockWeb
         /// </summary>
         public static bool CanConnect( ConnectionRequest connectionRequest, ConnectionOpportunity opportunity, Person currentPerson, Guid? safetySecurityRoleGuid )
         {
+            if ( connectionRequest == null )
+            {
+                return CanConnect( ( int? ) null, null, opportunity, currentPerson, safetySecurityRoleGuid );
+            }
+
+            return CanConnect( connectionRequest.ConnectionStatusId, connectionRequest.ConnectionState, opportunity, currentPerson, safetySecurityRoleGuid );
+        }
+
+        /// <summary>
+        /// Same gate, evaluated for an arbitrary status instead of a request. Lets callers ask
+        /// "could the person connect a request at this status?" (e.g. the board card action menu,
+        /// which must decide per status column). A null status means there is no request in context,
+        /// which is allowed (board add mode) so modal rendering isn't blocked.
+        /// </summary>
+        public static bool CanConnect( int? connectionStatusId, ConnectionState? connectionState, ConnectionOpportunity opportunity, Person currentPerson, Guid? safetySecurityRoleGuid )
+        {
             if ( opportunity == null )
             {
                 return false;
@@ -123,13 +139,13 @@ namespace RockWeb
                 return true;
             }
 
-            if ( connectionRequest == null )
+            if ( !connectionStatusId.HasValue )
             {
                 return true;
             }
 
-            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
-                || connectionRequest.ConnectionState == ConnectionState.Connected;
+            return connectableStatuses.Contains( connectionStatusId.Value )
+                || connectionState == ConnectionState.Connected;
         }
     }
 }

--- a/RockWeb/App_Code/SeccConnectGateHelper.cs
+++ b/RockWeb/App_Code/SeccConnectGateHelper.cs
@@ -1,0 +1,135 @@
+// <copyright>
+// Copyright Southeast Christian Church
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+using System;
+using System.Linq;
+
+using Rock;
+using Rock.Model;
+using Rock.Web.Cache;
+
+namespace RockWeb
+{
+    /// <summary>
+    /// SECC (ROCK-8640): Shared Safety &amp; Security connect-gate logic used by the
+    /// Connection Request Board and Connection Request Detail blocks. Opportunities
+    /// flagged as requiring security to connect may only be connected by Rock
+    /// Administrators or members of the block-configured Safety &amp; Security role.
+    /// </summary>
+    public static class SeccConnectGateHelper
+    {
+        /// <summary>
+        /// Attribute keys for the SecurityToConnect flag across all known opportunity types.
+        /// </summary>
+        private static readonly string[] SecurityToConnectAttributeKeys =
+        {
+            "SecurityToConnect",
+            "RequireSafetySecuritytoConnect",      // RISE
+            "RequireSafetyandSecuritytoConnect"    // Lightning Lane
+        };
+
+        /// <summary>
+        /// Returns the first non-null SecurityToConnect value found across all known attribute keys.
+        /// Assumes the opportunity's attributes have already been loaded.
+        /// </summary>
+        public static bool? GetRequiresSecurityToConnect( ConnectionOpportunity opportunity )
+        {
+            foreach ( var key in SecurityToConnectAttributeKeys )
+            {
+                var value = opportunity.GetAttributeValue( key ).AsBooleanOrNull();
+                if ( value.HasValue )
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns true if the person satisfies the S&amp;S connect gate:
+        /// Rock Administrators always pass; otherwise the person must be in the configured
+        /// Safety &amp; Security role. If no role is configured, only Rock Administrators pass.
+        /// </summary>
+        public static bool IsPersonAuthorizedToConnect( Person currentPerson, Guid? safetySecurityRoleGuid )
+        {
+            if ( currentPerson == null )
+            {
+                return false;
+            }
+
+            var adminRole = RoleCache.Get( Rock.SystemGuid.Group.GROUP_ADMINISTRATORS.AsGuid() );
+            if ( adminRole != null && adminRole.IsPersonInRole( currentPerson.Guid ) )
+            {
+                return true;
+            }
+
+            if ( !safetySecurityRoleGuid.HasValue )
+            {
+                return false;
+            }
+
+            var ssRole = RoleCache.Get( safetySecurityRoleGuid.Value );
+            return ssRole != null && ssRole.IsPersonInRole( currentPerson.Guid );
+        }
+
+        /// <summary>
+        /// Returns true if the person may connect the request, based on the opportunity's
+        /// SecurityToConnect flag, the configured Safety &amp; Security role, and the
+        /// opportunity's ConnectableStatuses.
+        /// Fails closed: returns false if the opportunity cannot be resolved.
+        /// A null request is allowed (board add mode) so modal rendering isn't blocked.
+        /// </summary>
+        public static bool CanConnect( ConnectionRequest connectionRequest, ConnectionOpportunity opportunity, Person currentPerson, Guid? safetySecurityRoleGuid )
+        {
+            if ( opportunity == null )
+            {
+                return false;
+            }
+
+            opportunity.LoadAttributes();
+            var requiresSecurityToConnect = GetRequiresSecurityToConnect( opportunity );
+
+            if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
+            {
+                return true;
+            }
+
+            if ( !IsPersonAuthorizedToConnect( currentPerson, safetySecurityRoleGuid ) )
+            {
+                return false;
+            }
+
+            var connectableStatuses = opportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
+                .Select( v => v.AsIntegerOrNull() )
+                .Where( v => v.HasValue )
+                .ToList();
+
+            if ( connectableStatuses.Count == 0 )
+            {
+                return true;
+            }
+
+            if ( connectionRequest == null )
+            {
+                return true;
+            }
+
+            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
+                || connectionRequest.ConnectionState == ConnectionState.Connected;
+        }
+    }
+}

--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -2532,11 +2532,45 @@ namespace RockWeb.Blocks.Connection
         /// </summary>
         private bool CanUserConnect()
         {
+            var connectionRequest = GetConnectionRequest();
+
             return SeccConnectGateHelper.CanConnect(
-                GetConnectionRequest(),
-                GetConnectionOpportunity(),
+                connectionRequest,
+                GetGateConnectionOpportunity( connectionRequest ),
                 CurrentPerson,
                 GetAttributeValue( AttributeKey.SafetySecurityRole ).AsGuidOrNull() );
+        }
+
+        /// <summary>
+        /// SECC (ROCK-8640): Returns the opportunity whose connect rules apply to the given request.
+        /// The request identifier arrives from the client, so it can belong to an opportunity other than the
+        /// one currently selected on the board. The gate has to read SecurityToConnect and ConnectableStatuses
+        /// from the request's own opportunity - which is what ConnectionRequestDetail does - otherwise a user
+        /// on an opportunity that does not require security could connect a request in one that does.
+        /// Falls back to the selected opportunity when there is no request in context (modal add mode), which
+        /// is the opportunity the new request will be created in.
+        /// </summary>
+        /// <param name="connectionRequest">The connection request, or null in modal add mode.</param>
+        private ConnectionOpportunity GetGateConnectionOpportunity( ConnectionRequest connectionRequest )
+        {
+            var selectedConnectionOpportunity = GetConnectionOpportunity();
+
+            if ( connectionRequest == null )
+            {
+                return selectedConnectionOpportunity;
+            }
+
+            // Reuse the already loaded instance when it is the right one, which is the normal case.
+            if ( selectedConnectionOpportunity != null
+                && selectedConnectionOpportunity.Id == connectionRequest.ConnectionOpportunityId )
+            {
+                return selectedConnectionOpportunity;
+            }
+
+            return new ConnectionOpportunityService( new RockContext() )
+                .Queryable()
+                .AsNoTracking()
+                .FirstOrDefault( co => co.Id == connectionRequest.ConnectionOpportunityId );
         }
 
         /// <summary>

--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -2540,6 +2540,61 @@ namespace RockWeb.Blocks.Connection
         }
 
         /// <summary>
+        /// SECC (ROCK-8640): Runs the shared gate against every status on the selected opportunity, so the
+        /// board card action menu can hide its Connect item using exactly the same rule that hides the
+        /// Connect button on the request modal. Presentation only - the card menu's postback is enforced
+        /// separately in ProcessJavaScriptCommand.
+        /// </summary>
+        private List<int> GetUserConnectableStatusIds()
+        {
+            var statusIds = new List<int>();
+
+            /*
+                The modal's Connect button also requires edit rights, so apply the same check here.
+
+                Note that no request is in context at bind time, so when the connection type has
+                EnableRequestSecurity turned on this evaluates opportunity-level Edit rather than the
+                per-request Edit the modal evaluates, and the card menu can show Connect for a request
+                the modal would hide. The card menu's postback is still evaluated per-request in
+                ProcessJavaScriptCommand, so this is a presentation difference only. Matching the modal
+                exactly here would require evaluating the gate per request instead of per status.
+            */
+            if ( !CanUserEditConnectionRequest() )
+            {
+                return statusIds;
+            }
+
+            var connectionOpportunity = GetConnectionOpportunity();
+
+            if ( connectionOpportunity == null
+                || connectionOpportunity.ConnectionType == null
+                || connectionOpportunity.ConnectionType.ConnectionStatuses == null )
+            {
+                return statusIds;
+            }
+
+            var safetySecurityRoleGuid = GetAttributeValue( AttributeKey.SafetySecurityRole ).AsGuidOrNull();
+
+            // Ordered so the same board state always produces the same list. The client stores these in its
+            // options object and re-renders the board when that object changes.
+            foreach ( var connectionStatus in connectionOpportunity.ConnectionType.ConnectionStatuses.OrderBy( cs => cs.Id ) )
+            {
+                /*
+                    Each status is evaluated as Active. State only affects the gate when it is Connected,
+                    and the client applies this list only to cards whose core CanConnect is already true --
+                    which is false for both Connected and Inactive requests -- so the state passed here
+                    cannot change the outcome.
+                */
+                if ( SeccConnectGateHelper.CanConnect( connectionStatus.Id, ConnectionState.Active, connectionOpportunity, CurrentPerson, safetySecurityRoleGuid ) )
+                {
+                    statusIds.Add( connectionStatus.Id );
+                }
+            }
+
+            return statusIds;
+        }
+
+        /// <summary>
         /// Binds the modal activities grid.
         /// </summary>
         private void BindRequestModalViewModeActivitiesGrid()
@@ -5293,7 +5348,8 @@ namespace RockWeb.Blocks.Connection
     statusIds: {8},
     connectionStates: {9},
     campusId: {10},
-    pastDueOnly: {11}
+    pastDueOnly: {11},
+    userConnectableStatusIds: {12}
 }});",
                 ToJavaScript( ConnectionRequestId ), // 0
                 ToJavaScript( whitespaceRemovedTemplate ), // 1
@@ -5306,7 +5362,8 @@ namespace RockWeb.Blocks.Connection
                 ToJavaScript( cblStatusFilter.SelectedValuesAsInt ), // 8
                 ToJavaScript( cblStateFilter.SelectedValues ), // 9
                 ToJavaScript( CampusId ), // 10
-                ToJavaScript( rcbPastDueOnly.Checked ) /* 11 */ );
+                ToJavaScript( rcbPastDueOnly.Checked ), // 11
+                ToJavaScript( GetUserConnectableStatusIds() ) /* 12 */ );
 
             ScriptManager.RegisterStartupScript(
                 upnlJavaScript,
@@ -5342,7 +5399,8 @@ namespace RockWeb.Blocks.Connection
     lastActivityTypeIds: {11},
     controlClientId: {12},
     pastDueOnly: {13},
-    connectionRequestId: {14}
+    connectionRequestId: {14},
+    userConnectableStatusIds: {15}
 }});",
                 ToJavaScript( ConnectionOpportunityId ), // 0
                 ToJavaScript( GetMaxCardsPerColumn() ), // 1
@@ -5358,7 +5416,8 @@ namespace RockWeb.Blocks.Connection
                 ToJavaScript( cblLastActivityFilter.SelectedValuesAsInt ), // 11
                 ToJavaScript( lbJavaScriptCommand.ClientID ), // 12
                 ToJavaScript( rcbPastDueOnly.Checked ), //13
-                ToJavaScript( ConnectionRequestId ) /* 14 */ );
+                ToJavaScript( ConnectionRequestId ), // 14
+                ToJavaScript( GetUserConnectableStatusIds() ) /* 15 */ );
 
             ScriptManager.RegisterStartupScript(
                 upnlJavaScript,

--- a/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestBoard.ascx.cs
@@ -159,7 +159,7 @@ namespace RockWeb.Blocks.Connection
 
     [SecurityRoleField(
         "Safety & Security Role",
-        Description = "If set, only members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect.",
+        Description = "Members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect. If an opportunity requires security to connect and no role is set here, only Rock Administrators can connect.",
         IsRequired = false,
         Order = 30,
         Key = AttributeKey.SafetySecurityRole )]
@@ -656,8 +656,13 @@ namespace RockWeb.Blocks.Connection
 
             if ( action == "connect" )
             {
-                MarkRequestConnected();
-                RefreshRequestCard();
+                // ROCK-8640: enforce edit rights and the S&S connect gate on the card-menu connect action.
+                if ( CanUserEditConnectionRequest() && CanUserConnect() )
+                {
+                    MarkRequestConnected();
+                    RefreshRequestCard();
+                }
+
                 return;
             }
 
@@ -2520,105 +2525,18 @@ namespace RockWeb.Blocks.Connection
         }
 
         /// <summary>
-        /// SECC: Returns true if the current user may connect the request, based on the opportunity's
-        /// SecurityToConnect flag and the configured Safety &amp; Security role.
-        /// Fails closed: returns false if the opportunity or request cannot be resolved.
+        /// SECC (ROCK-8640): Returns true if the current user may connect the request, based on the
+        /// opportunity's SecurityToConnect flag and the configured Safety &amp; Security role.
+        /// Shared gate logic lives in <see cref="SeccConnectGateHelper"/> (also used by ConnectionRequestDetail).
+        /// Fails closed: returns false if the opportunity cannot be resolved.
         /// </summary>
         private bool CanUserConnect()
         {
-            var connectionOpportunity = GetConnectionOpportunity();
-
-            if ( connectionOpportunity == null )
-            {
-                return false;
-            }
-
-            connectionOpportunity.LoadAttributes();
-            var requiresSecurityToConnect = GetRequiresSecurityToConnect( connectionOpportunity );
-
-            if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
-            {
-                return true;
-            }
-
-            if ( !UserIsAuthorizedToConnect() )
-            {
-                return false;
-            }
-
-            var connectableStatuses = connectionOpportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
-                .Select( v => v.AsIntegerOrNull() )
-                .Where( v => v.HasValue )
-                .ToList();
-
-            if ( connectableStatuses.Count == 0 )
-            {
-                return true;
-            }
-
-            var connectionRequest = GetConnectionRequest();
-
-            // Add mode: no request yet — don't block modal rendering.
-            if ( connectionRequest == null )
-            {
-                return true;
-            }
-
-            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
-                || connectionRequest.ConnectionState == ConnectionState.Connected;
-        }
-
-        /// <summary>
-        /// SECC: Returns true if the current person satisfies the S&amp;S connect gate:
-        /// Rock Administrators always pass; otherwise the person must be in the configured S&amp;S role.
-        /// If no S&amp;S role is configured, only Rock Administrators pass.
-        /// </summary>
-        private bool UserIsAuthorizedToConnect()
-        {
-            if ( CurrentPerson == null )
-            {
-                return false;
-            }
-
-            var adminRole = RoleCache.Get( Rock.SystemGuid.Group.GROUP_ADMINISTRATORS.AsGuid() );
-            if ( adminRole != null && adminRole.IsPersonInRole( CurrentPerson.Guid ) )
-            {
-                return true;
-            }
-
-            var roleGuid = GetAttributeValue( AttributeKey.SafetySecurityRole ).AsGuidOrNull();
-            if ( !roleGuid.HasValue )
-            {
-                return false;
-            }
-
-            var ssRole = RoleCache.Get( roleGuid.Value );
-            return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
-        }
-
-        // ROCK-8640: attribute keys for the SecurityToConnect flag across all opportunity types.
-        private static readonly string[] SecurityToConnectAttributeKeys =
-        {
-            "SecurityToConnect",
-            "RequireSafetySecuritytoConnect",      // RISE
-            "RequireSafetyandSecuritytoConnect"    // Lightning Lane
-        };
-
-        /// <summary>
-        /// SECC: Returns the first non-null SecurityToConnect value found across all known attribute keys.
-        /// </summary>
-        private static bool? GetRequiresSecurityToConnect( ConnectionOpportunity opportunity )
-        {
-            foreach ( var key in SecurityToConnectAttributeKeys )
-            {
-                var value = opportunity.GetAttributeValue( key ).AsBooleanOrNull();
-                if ( value.HasValue )
-                {
-                    return value;
-                }
-            }
-
-            return null;
+            return SeccConnectGateHelper.CanConnect(
+                GetConnectionRequest(),
+                GetConnectionOpportunity(),
+                CurrentPerson,
+                GetAttributeValue( AttributeKey.SafetySecurityRole ).AsGuidOrNull() );
         }
 
         /// <summary>
@@ -3232,7 +3150,8 @@ namespace RockWeb.Blocks.Connection
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         protected void btnRequestModalViewModeConnect_Click( object sender, EventArgs e )
         {
-            if ( !CanUserEditConnectionRequest() )
+            // ROCK-8640: also enforce the S&S connect gate server-side.
+            if ( !CanUserEditConnectionRequest() || !CanUserConnect() )
             {
                 return;
             }

--- a/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
+++ b/RockWeb/Blocks/Connection/ConnectionRequestDetail.ascx.cs
@@ -101,7 +101,7 @@ namespace RockWeb.Blocks.Connection
 
     [SecurityRoleField(
         "Safety & Security Role",
-        Description = "If set, only members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect.",
+        Description = "Members of this security role (plus Rock Administrators) can use the Connect button on opportunities that require security to connect. If an opportunity requires security to connect and no role is set here, only Rock Administrators can connect.",
         IsRequired = false,
         Order = 9,
         Key = AttributeKeys.SafetySecurityRole )]
@@ -778,6 +778,12 @@ namespace RockWeb.Blocks.Connection
                     connectionRequest.PersonAlias != null &&
                     connectionRequest.ConnectionOpportunity != null )
                 {
+                    // ROCK-8640: enforce the S&S connect gate server-side.
+                    if ( !CanUserConnect( connectionRequest ) )
+                    {
+                        return;
+                    }
+
                     bool okToConnect = true;
 
                     GroupMember groupMember = null;
@@ -2074,96 +2080,17 @@ namespace RockWeb.Blocks.Connection
         }
 
         /// <summary>
-        /// SECC: Returns true if the current request satisfies the S&amp;S connect gate for the opportunity.
+        /// SECC (ROCK-8640): Returns true if the current request satisfies the S&amp;S connect gate for the opportunity.
+        /// Shared gate logic lives in <see cref="SeccConnectGateHelper"/> (also used by ConnectionRequestBoard).
         /// Fails closed: returns false if the opportunity cannot be resolved.
         /// </summary>
         private bool CanUserConnect( ConnectionRequest connectionRequest )
         {
-            var opportunity = connectionRequest.ConnectionOpportunity;
-
-            if ( opportunity == null )
-            {
-                return false;
-            }
-
-            opportunity.LoadAttributes();
-            var requiresSecurityToConnect = GetRequiresSecurityToConnect( opportunity );
-
-            if ( !requiresSecurityToConnect.HasValue || !requiresSecurityToConnect.Value )
-            {
-                return true;
-            }
-
-            if ( !UserIsAuthorizedToConnect() )
-            {
-                return false;
-            }
-
-            var connectableStatuses = opportunity.GetAttributeValue( "ConnectableStatuses" ).SplitDelimitedValues()
-                .Select( v => v.AsIntegerOrNull() )
-                .Where( v => v.HasValue )
-                .ToList();
-
-            if ( connectableStatuses.Count == 0 )
-            {
-                return true;
-            }
-
-            return connectableStatuses.Contains( connectionRequest.ConnectionStatusId )
-                || connectionRequest.ConnectionState == ConnectionState.Connected;
-        }
-
-        // ROCK-8640: attribute keys for the SecurityToConnect flag across all opportunity types.
-        private static readonly string[] SecurityToConnectAttributeKeys =
-        {
-            "SecurityToConnect",
-            "RequireSafetySecuritytoConnect",      // RISE
-            "RequireSafetyandSecuritytoConnect"    // Lightning Lane
-        };
-
-        /// <summary>
-        /// SECC: Returns the first non-null SecurityToConnect value found across all known attribute keys.
-        /// </summary>
-        private static bool? GetRequiresSecurityToConnect( ConnectionOpportunity opportunity )
-        {
-            foreach ( var key in SecurityToConnectAttributeKeys )
-            {
-                var value = opportunity.GetAttributeValue( key ).AsBooleanOrNull();
-                if ( value.HasValue )
-                {
-                    return value;
-                }
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// True if the current person may bypass or satisfy the S&S connect gate:
-        /// Rock Administrators always may; otherwise the person must be in the configured S&S role.
-        /// If no S&S role is configured, only Rock Administrators pass.
-        /// </summary>
-        private bool UserIsAuthorizedToConnect()
-        {
-            if ( CurrentPerson == null )
-            {
-                return false;
-            }
-
-            var adminRole = RoleCache.Get( Rock.SystemGuid.Group.GROUP_ADMINISTRATORS.AsGuid() );
-            if ( adminRole != null && adminRole.IsPersonInRole( CurrentPerson.Guid ) )
-            {
-                return true;
-            }
-
-            var roleGuid = GetAttributeValue( AttributeKeys.SafetySecurityRole ).AsGuidOrNull();
-            if ( !roleGuid.HasValue )
-            {
-                return false;
-            }
-
-            var ssRole = RoleCache.Get( roleGuid.Value );
-            return ssRole != null && ssRole.IsPersonInRole( CurrentPerson.Guid );
+            return SeccConnectGateHelper.CanConnect(
+                connectionRequest,
+                connectionRequest?.ConnectionOpportunity,
+                CurrentPerson,
+                GetAttributeValue( AttributeKeys.SafetySecurityRole ).AsGuidOrNull() );
         }
 
         /// <summary>

--- a/RockWeb/Scripts/Rock/Controls/ConnectionRequestBoard/connectionRequestBoard.js
+++ b/RockWeb/Scripts/Rock/Controls/ConnectionRequestBoard/connectionRequestBoard.js
@@ -83,8 +83,34 @@
         };
         let _cardTemplate = '';
 
+        // ROCK-8640: the card action menu's Connect item is driven by the core CanConnect value, which knows
+        // nothing about the SECC Safety & Security gate. The server evaluates that gate (the same method that
+        // hides the Connect button on the request modal) for every status on the opportunity and sends the
+        // allowed status ids here, so this only has to check membership - no gate logic lives in JavaScript.
+        let _userConnectableStatusIds = null;
+
+        const captureConnectGate = function (options) {
+            if (options && options.userConnectableStatusIds) {
+                _userConnectableStatusIds = options.userConnectableStatusIds;
+            }
+        };
+
+        const applyConnectGate = function (viewModel) {
+            if (!viewModel || viewModel.CanConnect !== true || !_userConnectableStatusIds) {
+                return viewModel;
+            }
+
+            if (_userConnectableStatusIds.indexOf(viewModel.StatusId) !== -1) {
+                return viewModel;
+            }
+
+            const gated = $.extend({}, viewModel);
+            gated.CanConnect = false;
+            return gated;
+        };
+
         const getCardHtml = function (requestViewModel) {
-            return resolveTemplateFields(getCardTemplate(), requestViewModel);
+            return resolveTemplateFields(getCardTemplate(), applyConnectGate(requestViewModel));
         };
 
         const getSentryTemplate = function () {
@@ -248,6 +274,8 @@
             if (!options || !options.connectionRequestId) {
                 return
             }
+
+            captureConnectGate(options);
 
             fetchRequestViewModel(options, function (requestViewModel) {
                 refreshCard(options.connectionRequestId, requestViewModel);
@@ -643,6 +671,10 @@
             if (!options || !options.connectionOpportunityId || !options.controlClientId) {
                 throw 'A valid options object is required';
             }
+
+            // ROCK-8640: capture before the early return below, so the gate is applied even when the board
+            // itself does not need re-rendering.
+            captureConnectGate(options);
 
             // Check if this options object has already been initialized (no need to do it again)
             const newOptionsHash = JSON.stringify(options);


### PR DESCRIPTION
## Problem

PR #4 gated the Connect button on the request modal, but the kanban card's action menu ("...") has a second Connect item it did not cover:

```html
<!-- ConnectionRequestBoard.ascx:760 -->
<li class="can-connect-{{CanConnect}}">
    <a href="javascript:void(0);" class="js-connect">Connect</a>
</li>
```

It is rendered client-side from core `ConnectionRequestService.CanConnect()` — placement group assigned, state not Connected/Inactive, `ShowConnectButton` — which knows nothing about `SecurityToConnect`, `ConnectableStatuses`, or the `SafetySecurityRole` block setting. Clicking it posts `action=connect` straight into `MarkRequestConnected()`, which had no authorization check. PR #4 also left the gate implemented twice — once in the Board block, once in Detail.

Confirmed on DEV by impersonating a non-S&S connector: modal button correctly hidden, edit-modal state radio correctly reverts, Connect present only in the card dropdown. Scope on prod: ~103 connects by 13 non-S&S staff since 7/15 (~80 at a non-approved status); 1,161 cards exposing the item to the ~697 accounts that can view the board.

## Commit 1 — mirror hotfix-1.16.12 (backport of ROCK-8867 / PR #5)

Brings 1.13.7 to exactly what v16 runs, so both branches share one gate:

- **`RockWeb/App_Code/SeccConnectGateHelper.cs`** added — the helper from `hotfix-1.16.12`, copied verbatim (verified byte-identical before commit 2 extends it).
- Both blocks' private gate implementations (~187 lines duplicated across Board and Detail) replaced with thin wrappers calling the helper — same wrapper bodies as v16.
- **Server-side enforcement on every connect path**, matching v16: the card-menu `action=connect` postback (`CanUserEditConnectionRequest() && CanUserConnect()`), the board modal Connect click, and Detail's `lbConnect_Click`.
- Block setting descriptions updated to the v16 wording.

## Commit 2 — hide the card-menu Connect item (the new change)

- Helper gains a **status-based overload** — `CanConnect( int? statusId, ConnectionState? state, opportunity, person, roleGuid )` — with the request-based overload delegating to it. One implementation remains.
- `GetUserConnectableStatusIds()` runs that shared gate per status on the selected opportunity, plus the same edit-rights check the modal button applies, and the allowed ids ride both board script payloads.
- `connectionRequestBoard.js` checks membership only (`indexOf`) — no gate logic client-side. Cards re-gate on drag/status refresh via `fetchAndRefreshCard`.
- Net: the "..." menu shows Connect exactly when the modal button would show it — S&S/admin + Approved status on secured opportunities — and even a crafted postback is refused by commit 1's server check.

## Commit 3 — evaluate the gate against the request's own opportunity

Separate from the card work, and a pre-existing defect present both in the merged 13.7 change and in `hotfix-1.16.12`.

The board resolved the gate's opportunity from the **board's current selection**, while the request id arrives from the **client postback** — nothing checked that the two agree. A user with edit rights on an opportunity that does not require S&S to connect could send a connect postback carrying the id of a request in a gated opportunity: the gate read `SecurityToConnect` / `ConnectableStatuses` off the selected opportunity, allowed it, and `MarkRequestConnected()` connected the client-supplied request.

`GetGateConnectionOpportunity()` now resolves the opportunity from the request, matching what Detail already does. The selected opportunity is still used in modal add mode (that is the opportunity the new request is created in) and is reused directly when it already matches, so the normal path takes no extra query.

Internal-only reachability (board is staff-only, requires a hand-crafted postback), so this is a separable commit — drop it if the team rules the bypass accepted risk, and the card feature is unaffected.

## Carry-back to v16

`hotfix-1.16.12` already has commit 1. Cherry-pick **commits 2 and 3**; commit 2 must bring the helper overload so both branches keep a byte-identical `SeccConnectGateHelper.cs`.

## Verification

- `node --check` passes; both `string.Format` payloads verified against their argument lists (0–12, 0–15).
- C# 6 only (`web.config` pins `/langversion:6`; RockWeb blocks runtime-compile). `?.` is C# 6 and matches the v16 wrapper.
- No dangling references to the removed private members; Detail's `ShowReadonlyDetails` visibility gate retained.
- Prior single-commit version of the visibility change ran on DEV (board rendered, Connect hidden for a non-S&S user). The refactor + enforcement here still needs the DEV matrix below.

## Before deploy

1. **Grant `CS - Safety & Security | Workers` Edit on ConnectionTypes 1/3/9/10** — only 4 of 11 S&S members pass the edit check today; the rest lose Connect on both surfaces without this (auth inherits Request → Opportunity → ConnectionType).
2. DEV matrix: non-S&S user (Connect absent everywhere, connect postback refused); **Ange on an Approved card (Connect present — positive control)**; Ange on a Final S&S card (absent); unsecured opp 102 (present with edit rights).
3. S&S review of the ~80 non-approved placements (Cooper Witt → Toddlers, Julie Collier → Children's Library, Natosha Box → Student Volunteers first).

## Known issues, not fixed here

- **Drag/drop never refreshes the card.** `ProcessConfirmedDragEvent` assigns `ConnectionStatusId = newStatusId`, then tests `if ( request.ConnectionStatusId == newStatusId )` — always true — so the `RefreshRequestCard()` in the `else` is unreachable, and when the sort is not by Order neither branch runs. A dragged card therefore keeps its pre-drag menu state until the next refresh: dragging out of Approved leaves a visible Connect item (harmless, the postback is refused server-side), dragging into Approved leaves it hidden for S&S until refresh (use the card's Connect button). Core Rock defect, tracked separately.
- **`EnableRequestSecurity` seam.** No request is in context when the status list is built, so with that setting on the card menu evaluates opportunity-level Edit where the modal evaluates per-request Edit, and can over-show. The postback is still evaluated per-request. Documented in-code at the edit check; currently moot (setting off, no per-request Auth rows).
- **Opportunity 153 Guest Experience** has `ConnectableStatuses = 2`, a ConnectionType 1 status on a ConnectionType 10 opportunity, so no card there will ever match. Config fix, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

