### PR TITLE
Add explicit Newtonsoft.Json reference to Rock.Blocks for VS 2026 builds

### DIFF
--- a/Rock.Blocks/Rock.Blocks.csproj
+++ b/Rock.Blocks/Rock.Blocks.csproj
@@ -41,6 +41,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Rock.Blocks/packages.config
+++ b/Rock.Blocks/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="UAParser" version="3.1.44" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Problem

Building the Rock solution with **VS 2026 (v18)** fails `Rock.Blocks` with ~10x:

```
error CS0012: The type 'JObject' is defined in an assembly that is not referenced.
You must add a reference to assembly 'Newtonsoft.Json, Version=13.0.0.0, ...'
```

plus a cascading `Could not get dependencies for project reference 'Rock.Blocks'` from RockWeb. The identical tree builds clean under VS 2022.

## Cause

`Rock/Utility/ExtensionMethods/JsonExtensions.cs` defines `ToDictionary(this JObject)` in namespace `Rock`, so every `.ToDictionary()`/LINQ binding in Rock.Blocks puts `JObject` in the overload-candidate set. Classic (non-SDK) csproj builds never pass transitive dependencies to csc, and Rock.Blocks has never referenced Newtonsoft.Json directly. VS 2026's Roslyn now requires the reference where VS 2022's did not.

## Fix

Add the explicit `Newtonsoft.Json 13.0.1` reference to `Rock.Blocks.csproj` + `packages.config`. The package is already in the solution `packages` folder and the DLL already ships in `RockWeb\Bin`, so there is no output change — this only lets the compile succeed.

Verified locally: VS 2026 MSBuild fails before / builds clean after; VS 2022 unaffected.

## Forward-compat note

Upstream resolves this from **v18.1** onward by converting Rock.Blocks to an SDK-style project (transitive refs flow to the compiler there). All 17.x hotfix branches still have the classic csproj without the reference, so this commit should be **cherry-picked onto each future 1.16.x/17.x-based branch** and dropped once we're on 18.1+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)